### PR TITLE
Remove numeric tier labels, use canonical names only

### DIFF
--- a/00-os/tiering.md
+++ b/00-os/tiering.md
@@ -1,14 +1,15 @@
 # Sensitivity Tiering
 
+**Note:** Named tiers are authoritative. Numeric labels are intentionally not used to avoid ambiguity.
+
 ## Tiers
-- **Tier 0 (Public)**: Safe for public repositories.
-- **Tier 1 (Internal)**: Non-sensitive but private context.
-- **Tier 2 (Sensitive)**: Operational details, strategy, or internal process.
-- **Tier 3 (Restricted)**: Credentials, PII, customer data (never store here).
+- **Public**: Safe for public repositories.
+- **Internal**: Private repo only. Non-sensitive operational context.
+- **Secret**: Never committed (keys, tokens, credentials, PII, customer data).
 
 ## Rules
-- Plane A: Tier 0 only.
-- Plane B: Tier 0–2 allowed; Tier 3 prohibited.
+- Plane A: Public only.
+- Plane B: Public and Internal allowed; Secret prohibited (never store here).
 - If classification is unclear, default to higher tier and add TODO.
 
 ## TODO

--- a/10-templates/repo-starters/docs-ai-context.md
+++ b/10-templates/repo-starters/docs-ai-context.md
@@ -14,8 +14,8 @@
 - Commit or PR expectations
 
 ## Safety & Publication
-- Allowed content (Tier 0 only)
-- Redaction rules
+- Allowed content: Public only
+- Redaction rules for Internal and Secret content
 
 ## TODO
 - Insert repo-specific constraints.

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ Exact contents may evolve, but the separation of concerns should remain.
 
 This repository is private by design, but still follows strict rules:
 
-- **No secrets, tokens, or credentials** are stored here
-- Sensitivity is explicitly tiered (Public / Internal / Secret)
-- Only Public-tier artifacts are allowed to leave this repo
+- **No secrets or credentials** are stored here
+- Sensitivity is explicitly tiered: **Public, Internal, Secret**
+- Only Public artifacts are allowed to leave this repo
+- Secret (credentials, tokens, PII) is never committed
 - Assume anything copied into a code repo may become public
 
 ---


### PR DESCRIPTION
## Summary
- Remove Tier 0-3 numeric labels from 00-os/tiering.md
- Use only canonical tier names: Public, Internal, Secret
- Align definitions with canvas.md (authoritative source)
- Add note that named tiers are authoritative to avoid ambiguity

## Why
Numeric tiers create unnecessary ambiguity. Canonical names (Public, Internal, Secret) are clearer and match canvas.md.