### PR TITLE
Copilot: Add PR close/supersede lifecycle

### DIFF
--- a/canvas.md
+++ b/canvas.md
@@ -142,9 +142,9 @@ PRs are not deleted; they are merged or closed. Prefer `gh` over manual UI.
 
 **Closure hygiene (required):**
 1) Leave a final comment stating why it is being closed and (if applicable) what replaces it.
-2) Apply labels:
-   - `status:closed`
-   - `status:superseded` (only if replaced by another PR)
+2) Apply exactly one status label:
+   - `status:closed` (default)
+   - `status:superseded` (use instead of `status:closed` when replaced by another PR)
    - Remove any `status:needs-review`, `status:changes-requested`, `status:approved`
 3) Delete the remote branch after closing unless intentionally retained.
 
@@ -152,29 +152,22 @@ PRs are not deleted; they are merged or closed. Prefer `gh` over manual UI.
 Close with comment:
 
 ```bash
-gh pr close <PR_NUMBER> --comment "Closing PR: <reason>. Superseded by #<NEW_PR_NUMBER> (if applicable)."
+gh pr close <PR_NUMBER> --comment "Closing PR: <reason>. Superseded by #<NEW_PR_NUMBER> (if applicable)." --delete-branch
 ```
 
 Set closed labels:
 
 ```bash
-gh pr edit <PR_NUMBER> --add-label "status:closed" --remove-label "status:needs-review" --remove-label "status:changes-requested" --remove-label "status:approved"
+gh pr edit <PR_NUMBER> --add-label "status:closed" --remove-label "status:superseded" --remove-label "status:needs-review" --remove-label "status:changes-requested" --remove-label "status:approved"
 ```
 
 Add superseded label (optional):
 
 ```bash
-gh pr edit <PR_NUMBER> --add-label "status:superseded"
+gh pr edit <PR_NUMBER> --add-label "status:superseded" --remove-label "status:closed" --remove-label "status:needs-review" --remove-label "status:changes-requested" --remove-label "status:approved"
 ```
 
-Delete remote branch:
-
-```bash
-BRANCH_NAME="$(gh pr view <PR_NUMBER> --json headRefName --jq .headRefName)"
-ENCODED_BRANCH_NAME="${BRANCH_NAME//\//%2F}"
-
-gh api -X DELETE "repos/:owner/:repo/git/refs/heads/${ENCODED_BRANCH_NAME}"
-```
+If the branch should be retained, omit the `--delete-branch` flag.
 
 ---
 
@@ -234,6 +227,8 @@ Labels make role and status visible at a glance and must be applied on every PR.
 - `status:changes-requested`
 - `status:approved`
 - `status:merged`
+- `status:closed`
+- `status:superseded`
 
 **Rule:** Labels should be applied/updated by the actor (Copilot/Codex/CEO) via `gh` as part of the workflow — manual labeling is the exception, not the norm.
 

--- a/canvas.md
+++ b/canvas.md
@@ -170,9 +170,10 @@ gh pr edit <PR_NUMBER> --add-label "status:superseded"
 Delete remote branch:
 
 ```bash
-gh pr view <PR_NUMBER> --json headRefName --jq .headRefName
-# then
-gh api -X DELETE repos/:owner/:repo/git/refs/heads/<branch-name>
+BRANCH_NAME="$(gh pr view <PR_NUMBER> --json headRefName --jq .headRefName)"
+ENCODED_BRANCH_NAME="${BRANCH_NAME//\//%2F}"
+
+gh api -X DELETE "repos/:owner/:repo/git/refs/heads/${ENCODED_BRANCH_NAME}"
 ```
 
 ---

--- a/canvas.md
+++ b/canvas.md
@@ -129,6 +129,52 @@ All meaningful changes in this repo should be **reviewable**. The default workfl
  - Templates and checklists preferred over long prose
  - TODOs added where human judgment is needed
 
+### PR lifecycle: close / supersede / cleanup
+PRs are not deleted; they are merged or closed. Prefer `gh` over manual UI.
+
+**Close a PR** when:
+- It is stale/abandoned
+- It is out of scope and rescoping is not worth it
+- It is superseded by another PR
+
+**Prefer rescoping (rewrite/rebase)** when:
+- The PR is fundamentally correct but contains extra commits/files
+
+**Closure hygiene (required):**
+1) Leave a final comment stating why it is being closed and (if applicable) what replaces it.
+2) Apply labels:
+   - `status:closed`
+   - `status:superseded` (only if replaced by another PR)
+   - Remove any `status:needs-review`, `status:changes-requested`, `status:approved`
+3) Delete the remote branch after closing unless intentionally retained.
+
+**Canonical `gh` commands**
+Close with comment:
+
+```bash
+gh pr close <PR_NUMBER> --comment "Closing PR: <reason>. Superseded by #<NEW_PR_NUMBER> (if applicable)."
+```
+
+Set closed labels:
+
+```bash
+gh pr edit <PR_NUMBER> --add-label "status:closed" --remove-label "status:needs-review" --remove-label "status:changes-requested" --remove-label "status:approved"
+```
+
+Add superseded label (optional):
+
+```bash
+gh pr edit <PR_NUMBER> --add-label "status:superseded"
+```
+
+Delete remote branch:
+
+```bash
+gh pr view <PR_NUMBER> --json headRefName --jq .headRefName
+# then
+gh api -X DELETE repos/:owner/:repo/git/refs/heads/<branch-name>
+```
+
 ---
 
 ## Role Attribution & Auditability (Humans vs Agents)


### PR DESCRIPTION
## Summary

This PR implements deterministic PR closure/supersede/cleanup workflows per issue #13.

## Changes
- Added **`### PR lifecycle: close / supersede / cleanup`** section to `canvas.md`
- Documented when to close vs. rescope PRs
- Included closure hygiene checklist (comment, labels, branch deletion)
- Provided canonical `gh` commands for:
  - Closing PRs with comments
  - Setting closure labels
  - Adding superseded labels
  - Deleting remote branches
- Created `status:closed` and `status:superseded` labels

## Machine-readable metadata
**Primary-Actor:** Copilot  
**Reviewed-By:** N/A  
**CEO-Approval:** Required

## Acceptance Criteria
- [x] Only `canvas.md` was modified
- [x] `canvas.md` includes a `### PR lifecycle: close / supersede / cleanup` section with canonical commands
- [x] Labels `status:closed` and `status:superseded` exist in the repo
- [x] No secrets, tokens, internal hostnames, IPs, or personal data introduced
- [x] Commit message starts with `[Copilot]`
- [x] PR description includes Primary-Actor, Reviewed-By, CEO-Approval metadata
- [ ] PR labels applied via `gh`: `agent:copilot`, `role:CEO`, `status:needs-review`

Closes #13
