### PR TITLE
Adopt HR role model and role charters

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-request.md
+++ b/.github/ISSUE_TEMPLATE/change-request.md
@@ -18,8 +18,8 @@ labels: ["change-request"]
 - 
 
 ## Role Attribution
-- **Proposed Implementer:** (Copilot / Codex / Human)
-- **Expected Reviewer:** (Codex / CEO)
+- **Proposed Implementer:** (Implementation Specialist / Business Analyst / AI Governance Manager)
+- **Expected Reviewer:** (Compliance Officer / Executive Sponsor)
 
 ## Notes
 - 

--- a/.github/ISSUE_TEMPLATE/repo-publish-request.md
+++ b/.github/ISSUE_TEMPLATE/repo-publish-request.md
@@ -23,8 +23,8 @@ labels: ["publish-request"]
 - 
 
 ## Role Attribution
-- **Proposed Implementer:** (Copilot / Codex / Human)
-- **Expected Reviewer:** (Codex / CEO)
+- **Proposed Implementer:** (Implementation Specialist / AI Governance Manager)
+- **Expected Reviewer:** (Compliance Officer / Executive Sponsor)
 
 ## Notes
 - 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ Treat the following files as **ground truth**:
 
 - `governance.md` — AI Context & Workspace Operating Model  
 - `context-flow.md` — Visual context flow and lifecycle  
+- `00-os/role-charters/` — Canonical HR role definitions
 
 If something is unclear, prefer adding a TODO rather than inventing behavior that contradicts these documents.
 
@@ -31,6 +32,14 @@ You should optimize for:
 - Durability
 - Portability across tools/LLMs
 - Clarity for future agents
+
+---
+
+## Role framing (required)
+
+- Declare your assigned role before task details (role first, tool second)
+- Treat tools (Copilot, Codex, Continue, ChatGPT) as assignment metadata
+- Escalate protected-path approvals to the Executive Sponsor
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,16 +5,16 @@
 - Linked issue:
 
 # Machine-Readable Metadata (Required)
-Primary-Actor:
-Reviewed-By:
-CEO-Approval:
+Primary-Role:
+Reviewed-By-Role:
+Executive-Sponsor-Approval:
 
 # Role Attribution
-- **Primary Actor:** (Copilot / Codex / CEO)
-- [ ] Commit messages include role prefixes ([Copilot], [Codex], [CEO])
-- [ ] At least one role label applied (agent:copilot / agent:codex / role:CEO)
+- **Primary Role:** (Executive Sponsor / AI Governance Manager / Compliance Officer / Business Analyst / Implementation Specialist)
+- [ ] Commit messages include role prefixes ([Executive Sponsor], [AI Governance Manager], [Compliance Officer], [Business Analyst], [Implementation Specialist])
+- [ ] At least one role label applied (role:executive-sponsor / role:ai-governance-manager / role:compliance-officer / role:business-analyst / role:implementation-specialist)
 - [ ] Exactly one status:* label applied
-- [ ] CEO approval provided (required for protected paths)
+- [ ] Executive Sponsor approval provided (required for protected paths)
 
 # Review Gate (Minimum)
 - [ ] No secrets, tokens, internal hostnames, or personal data
@@ -24,8 +24,8 @@ CEO-Approval:
 - [ ] TODOs added where human judgment is required
 
 # Protected Changes Logic
-- [ ] `governance.md`, `context-flow.md`, or `00-os/` touched → CEO approval required
-- [ ] Plane A/B boundary changes detected → CEO approval required
+- [ ] `governance.md`, `context-flow.md`, or `00-os/` touched → Executive Sponsor approval required
+- [ ] Plane A/B boundary changes detected → Executive Sponsor approval required
 
 # Low-Risk Fast-Track
 - [ ] Only low-risk paths changed (10-templates/, 30-vendor-notes/, new 20-canvases/)

--- a/00-os/org-model.md
+++ b/00-os/org-model.md
@@ -4,28 +4,31 @@
 - Define roles and responsibilities for the context system.
 
 ## Roles
-- **CEO**
+- **Executive Sponsor**
   - Vision, priorities, constraints
   - Approves publishable extracts
-- **Director of AI Context**
+- **AI Governance Manager**
   - Designs context system
   - Curates and sanitizes outputs
   - Maintains Plane B assets
-- **Reviewer / Merge Agent — Codex (optional)**
-  - Reviews agent PRs for alignment with operating model
+- **Compliance Officer (optional)**
+  - Reviews implementation output for alignment with operating model
   - Uses deterministic checklists (no intuition-only approvals)
   - Flags security leaks, scope creep, Plane A/B violations
   - Recommends approve / request changes
-  - Does not merge protected changes without CEO sign-off
-- **Agents (Copilot/Codex/Continue)**
+  - Does not merge protected changes without Executive Sponsor sign-off
+- **Implementation Specialist**
   - Execute tasks within repo constraints
   - Produce drafts, artifacts, diffs
+- **Business Analyst**
+  - Performs exploratory analysis and planning
+  - Proposes changes and drafts work orders
 
 ## RACI (lightweight)
-- **Strategy**: CEO (A), Director (R)
-- **System design**: Director (A/R)
-- **Execution**: Agents (R), Director (A)
-- **Publication**: Director (R), CEO (A)
+- **Strategy**: Executive Sponsor (A), AI Governance Manager (R)
+- **System design**: AI Governance Manager (A/R)
+- **Execution**: Implementation Specialist (R), AI Governance Manager (A)
+- **Publication**: AI Governance Manager (R), Executive Sponsor (A)
 
 ## Escalation
 - If ambiguity persists, add TODO and request decision.

--- a/00-os/role-charters/README.md
+++ b/00-os/role-charters/README.md
@@ -1,0 +1,20 @@
+# Role Charters (Canonical)
+
+## Purpose
+- Provide durable, role-first job descriptions for the context system.
+- Keep tool names as assignment metadata, not role identity.
+
+## Scope
+- Canonical HR roles for Context-Engineering.
+- Charters are reference material for responsibilities and escalation.
+
+## Precedence
+- If any charter conflicts with governance.md, governance.md is authoritative.
+
+## Naming Convention
+- Lowercase kebab-case file names (example: executive-sponsor.md).
+
+## How To Use
+- Start with the template in 10-templates/role-charters/_template-role-charter.md.
+- Keep charters concise and role-focused.
+- Add TODOs where human judgment or thresholds are required.

--- a/00-os/role-charters/ai-governance-manager.md
+++ b/00-os/role-charters/ai-governance-manager.md
@@ -1,0 +1,37 @@
+# AI Governance Manager
+
+## Role Purpose
+- Maintain the context system and its durable artifacts.
+- Curate and sanitize outputs for Plane A.
+
+## Core Responsibilities
+- Design and update context structures and templates.
+- Curate publishable extracts and ensure public-safe content.
+- Coordinate role attribution and auditability requirements.
+
+## Explicit Non-Responsibilities
+- Does not approve protected changes.
+- Does not bypass Compliance Officer review.
+
+## Decision Rights (Approve / Recommend / Execute / Escalate)
+- Approve: Routine, non-protected updates within scope.
+- Recommend: Governance updates and workflow changes.
+- Execute: Template and documentation updates.
+- Escalate: Protected changes and boundary shifts.
+
+## Escalation Triggers
+- Any protected-path change.
+- Plane A/B boundary changes or ambiguity.
+
+## Required Inputs and References
+- governance.md
+- context-flow.md
+- 00-os/ policies and templates
+
+## Success Measures
+- Context system remains consistent and portable.
+- Publication outputs remain public-safe.
+
+## Assignment Notes (Human/AI occupant + optional tool)
+- Human or AI occupant permitted.
+- Tool metadata optional.

--- a/00-os/role-charters/business-analyst.md
+++ b/00-os/role-charters/business-analyst.md
@@ -1,0 +1,37 @@
+# Business Analyst
+
+## Role Purpose
+- Analyze current state and propose changes.
+- Translate goals into scoped work orders.
+
+## Core Responsibilities
+- Draft issues, plans, and acceptance criteria.
+- Identify risks, gaps, and dependencies.
+- Provide role-based recommendations.
+
+## Explicit Non-Responsibilities
+- Does not approve protected changes.
+- Does not execute implementation tasks unless assigned separately.
+
+## Decision Rights (Approve / Recommend / Execute / Escalate)
+- Approve: N/A.
+- Recommend: Scope, sequencing, and priorities.
+- Execute: Draft planning artifacts.
+- Escalate: Ambiguity or policy conflicts.
+
+## Escalation Triggers
+- Conflicts between goals and governance.
+- Missing authority or unclear scope.
+
+## Required Inputs and References
+- governance.md
+- canvas.md
+- 00-os/ workflows and templates
+
+## Success Measures
+- Issues and plans are clear, scoped, and auditable.
+- Recommendations reduce ambiguity.
+
+## Assignment Notes (Human/AI occupant + optional tool)
+- Human or AI occupant permitted.
+- Tool metadata optional.

--- a/00-os/role-charters/compliance-officer.md
+++ b/00-os/role-charters/compliance-officer.md
@@ -1,0 +1,36 @@
+# Compliance Officer
+
+## Role Purpose
+- Verify alignment with governance and security rules.
+- Provide deterministic review outcomes.
+
+## Core Responsibilities
+- Review changes for alignment with governance.md.
+- Check for security, scope, and Plane A/B violations.
+- Produce PR Review Reports and enforce label updates.
+
+## Explicit Non-Responsibilities
+- Does not approve protected changes.
+- Does not merge protected-path changes.
+
+## Decision Rights (Approve / Recommend / Execute / Escalate)
+- Approve: Non-protected changes that meet all gates.
+- Recommend: Adjustments to bring work into compliance.
+- Execute: Review labeling actions.
+- Escalate: Protected changes or boundary shifts.
+
+## Escalation Triggers
+- Protected paths touched without explicit approval.
+- Any ambiguity in governance interpretation.
+
+## Required Inputs and References
+- governance.md
+- review checklists and PR templates
+
+## Success Measures
+- Reviews are deterministic and auditable.
+- Risk flags are identified early.
+
+## Assignment Notes (Human/AI occupant + optional tool)
+- Human or AI occupant permitted.
+- Tool metadata optional.

--- a/00-os/role-charters/executive-sponsor.md
+++ b/00-os/role-charters/executive-sponsor.md
@@ -1,0 +1,37 @@
+# Executive Sponsor
+
+## Role Purpose
+- Provide final authority for protected changes and publication decisions.
+- Set vision, priorities, and constraints for the context system.
+
+## Core Responsibilities
+- Approve protected-path changes and Plane A/B boundary shifts.
+- Decide what becomes public vs private.
+- Resolve escalation items from other roles.
+
+## Explicit Non-Responsibilities
+- Does not execute routine implementation tasks.
+- Does not replace Compliance Officer review.
+
+## Decision Rights (Approve / Recommend / Execute / Escalate)
+- Approve: Protected changes, publishable extracts, boundary shifts.
+- Recommend: Strategic direction and priorities.
+- Execute: Direct edits when necessary.
+- Escalate: N/A.
+
+## Escalation Triggers
+- Conflicts between governance and proposed changes.
+- High-risk or ambiguous publication decisions.
+
+## Required Inputs and References
+- governance.md
+- context-flow.md
+- 00-os/ workflows and security rules
+
+## Success Measures
+- Protected changes are approved explicitly and traceably.
+- Plane A/B boundaries remain intact.
+
+## Assignment Notes (Human/AI occupant + optional tool)
+- Human occupant expected.
+- Tool metadata optional.

--- a/00-os/role-charters/implementation-specialist.md
+++ b/00-os/role-charters/implementation-specialist.md
@@ -1,0 +1,36 @@
+# Implementation Specialist
+
+## Role Purpose
+- Execute scoped changes within defined constraints.
+
+## Core Responsibilities
+- Implement changes exactly as specified.
+- Keep work scoped to the Issue and instructions.
+- Add TODOs where human judgment is required.
+
+## Explicit Non-Responsibilities
+- Does not approve protected changes.
+- Does not expand scope without explicit instruction.
+
+## Decision Rights (Approve / Recommend / Execute / Escalate)
+- Approve: N/A.
+- Recommend: Clarifications or scope adjustments.
+- Execute: Edits within the authorized scope.
+- Escalate: Protected paths or ambiguity.
+
+## Escalation Triggers
+- Instructions conflict with governance.
+- Scope exceeds authorization.
+
+## Required Inputs and References
+- governance.md
+- context-flow.md
+- role charters and task briefs
+
+## Success Measures
+- Changes are accurate, minimal, and reversible.
+- No protected changes without approval.
+
+## Assignment Notes (Human/AI occupant + optional tool)
+- Human or AI occupant permitted.
+- Tool metadata optional.

--- a/00-os/workflow.md
+++ b/00-os/workflow.md
@@ -4,10 +4,10 @@
 1. **Issue**: Objective, scope, constraints, definition of done
 2. **Branch**: Focused edits with minimal scope
 3. **Pull Request**: Use templates + checklists
-4. **Review**: Codex review + human decision where required
+4. **Review**: Compliance Officer review + human decision where required
 5. **Merge**: Human merge for protected changes
 
-## Protected Changes (Require CEO Approval)
+## Protected Changes (Require Executive Sponsor Approval)
 - `governance.md` and `context-flow.md`
 - Anything under `00-os/`
 - Any change that affects Plane A vs Plane B boundaries

--- a/10-templates/agent-prompts/codex-pr-review-checklist.md
+++ b/10-templates/agent-prompts/codex-pr-review-checklist.md
@@ -1,6 +1,6 @@
 # Codex PR Review Checklist (Template)
 
-This file is a checklist + post-review enforcement actions for Codex.
+This file is a checklist + post-review enforcement actions for the Compliance Officer (Codex assignment).
 
 Canonical review brief and required PR Review Report format: `10-templates/codex-pr-review-brief.md` (source of truth: `governance.md`).
 
@@ -10,8 +10,8 @@ Canonical review brief and required PR Review Report format: `10-templates/codex
 - Scope summary:
 
 ## Blockers (REQUEST CHANGES if any fail)
-- [ ] PR description includes all three exact metadata keys (Primary-Actor:, Reviewed-By:, CEO-Approval:)
-- [ ] At least one role label exists (agent:copilot / agent:codex / role:CEO)
+- [ ] PR description includes all three exact metadata keys (Primary-Role:, Reviewed-By-Role:, Executive-Sponsor-Approval:)
+- [ ] At least one role label exists (role:implementation-specialist / role:compliance-officer / role:ai-governance-manager / role:business-analyst / role:executive-sponsor)
 - [ ] Exactly one status:* label exists
 
 ## Review Gate (Minimum)
@@ -22,18 +22,18 @@ Canonical review brief and required PR Review Report format: `10-templates/codex
 - [ ] TODOs added where human judgment is required
 
 ## Role Attribution Verification
-- [ ] Commit messages include role prefixes ([Copilot], [Codex], [CEO])
-- [ ] PR title or labels identify the primary actor
-- [ ] CEO approval comment exists when required (protected paths)
+- [ ] Commit messages include role prefixes ([Implementation Specialist], [Compliance Officer], [AI Governance Manager], [Business Analyst], [Executive Sponsor])
+- [ ] PR title or labels identify the primary role
+- [ ] Executive Sponsor approval comment exists when required (protected paths)
 
 ## Protected Changes Logic
-- [ ] `governance.md`, `context-flow.md`, or `00-os/` touched → CEO approval required
-- [ ] Plane A/B boundary changes detected → CEO approval required
+- [ ] `governance.md`, `context-flow.md`, or `00-os/` touched → Executive Sponsor approval required
+- [ ] Plane A/B boundary changes detected → Executive Sponsor approval required
 
 ## Decision
 - [ ] Approve
 - [ ] Request changes (list blockers)
-- [ ] Escalate to CEO
+- [ ] Escalate to Executive Sponsor
 
 ### Required Enforcement Actions (Post-Review)
 
@@ -47,22 +47,22 @@ gh pr comment <PR_NUMBER> --body-file <PATH_TO_PR_REVIEW_REPORT_MD>
 ```
 
 **If verdict = REQUEST CHANGES**
-- Apply label `agent:codex`
+- Apply label `role:compliance-officer`
 - Apply label `status:changes-requested`
 - Remove label `status:needs-review` if present
 
 **If verdict = APPROVE**
-- Apply label `agent:codex`
+- Apply label `role:compliance-officer`
 - Apply label `status:approved`
 - Remove labels `status:needs-review` and `status:changes-requested` if present
 
-**If PR touches protected paths and an explicit CEO approval comment exists**
-- Optionally apply label `role:CEO-approved`
+**If PR touches protected paths and an explicit Executive Sponsor approval comment exists**
+- Optionally apply label `role:executive-sponsor-approved`
 
 All label changes must be executed using `gh pr edit`.
 
-Codex must request permission before executing shell commands.
-Codex must not merge the PR.
+Compliance Officer (Codex assignment) must request permission before executing shell commands.
+Compliance Officer (Codex assignment) must not merge the PR.
 
 ## TODO
 - Add repo-specific gates (tests, lint, etc.).

--- a/10-templates/agent-prompts/codex-task-brief.md
+++ b/10-templates/agent-prompts/codex-task-brief.md
@@ -1,7 +1,7 @@
 # Codex Task Brief (Template)
 
 ## Role
-- PR Reviewer / Merge Agent (deterministic)
+- Compliance Officer (deterministic)
 
 ## Task
 - [ ] Objective
@@ -10,19 +10,19 @@
 
 ## Deterministic Checklist
 - [ ] Review gate (minimum) passed
-- [ ] Role attribution verified (commit prefixes, PR metadata, CEO approval if required)
-- [ ] Protected changes detected? If yes → escalate to CEO
+- [ ] Role attribution verified (commit prefixes, PR metadata, Executive Sponsor approval if required)
+- [ ] Protected changes detected? If yes → escalate to Executive Sponsor
 - [ ] Plane A/B boundaries preserved
 - [ ] Templates/checklists used where applicable
 - [ ] TODOs added where judgment is required
 
 ## Escalation Rules
-- If `governance.md`, `context-flow.md`, or `00-os/` changed → CEO approval required
-- If Plane A/B boundary changes detected → CEO approval required
+- If `governance.md`, `context-flow.md`, or `00-os/` changed → Executive Sponsor approval required
+- If Plane A/B boundary changes detected → Executive Sponsor approval required
 - If any review gate item fails → request changes
 
 ## Output Expectations
-- Decision: Approve / Request changes / Escalate to CEO
+- Decision: Approve / Request changes / Escalate to Executive Sponsor
 - List concrete blockers if requesting changes
 
 ## TODO

--- a/10-templates/agent-prompts/continue-task-brief.md
+++ b/10-templates/agent-prompts/continue-task-brief.md
@@ -1,5 +1,10 @@
 # Continue Task Brief (Template)
 
+## Assigned Role
+- Role: Implementation Specialist
+- Role charter: 00-os/role-charters/implementation-specialist.md
+- Tool (assignment metadata): Continue
+
 ## Task
 - [ ] Objective
 - [ ] Constraints

--- a/10-templates/agent-prompts/copilot-task-brief.md
+++ b/10-templates/agent-prompts/copilot-task-brief.md
@@ -1,5 +1,10 @@
 # Copilot Task Brief (Template)
 
+## Assigned Role
+- Role: Implementation Specialist
+- Role charter: 00-os/role-charters/implementation-specialist.md
+- Tool (assignment metadata): Copilot
+
 ## Task
 - [ ] Objective
 - [ ] Constraints

--- a/10-templates/agent-work-orders/copilot-work-order.md
+++ b/10-templates/agent-work-orders/copilot-work-order.md
@@ -58,13 +58,13 @@ Use checkboxes. Make these **binary** (pass/fail).
 - [ ] Only files listed in Scope were modified
 - [ ] All required content was added/updated exactly as specified
 - [ ] No secrets, tokens, internal hostnames, IPs, or personal data introduced
-- [ ] Commit message starts with `[Copilot]`
+- [ ] Commit message starts with `[Implementation Specialist]`
 - [ ] PR description includes:
-  - `Primary-Actor: Copilot`
-  - `Reviewed-By: N/A` (or a named reviewer if specified)
-  - `CEO-Approval: Not-Required` (or `Required` / `Provided` if protected paths are touched)
+  - `Primary-Role: Implementation Specialist`
+  - `Reviewed-By-Role: N/A` (or a named reviewer if specified)
+  - `Executive-Sponsor-Approval: Not-Required` (or `Required` / `Provided` if protected paths are touched)
 - [ ] PR labels applied via `gh`:
-  - `agent:copilot`
+  - `role:implementation-specialist`
   - exactly one `status:*` label (`status:needs-review`)
 
 ## PR Instructions

--- a/10-templates/agent-work-orders/copilot-work-order.md
+++ b/10-templates/agent-work-orders/copilot-work-order.md
@@ -61,7 +61,7 @@ Use checkboxes. Make these **binary** (pass/fail).
 - [ ] Commit message starts with `[Implementation Specialist]`
 - [ ] PR description includes:
   - `Primary-Role: Implementation Specialist`
-  - `Reviewed-By-Role: N/A` (or a named reviewer if specified)
+  - `Reviewed-By-Role: N/A` (or a canonical role if specified)
   - `Executive-Sponsor-Approval: Not-Required` (or `Required` / `Provided` if protected paths are touched)
 - [ ] PR labels applied via `gh`:
   - `role:implementation-specialist`

--- a/10-templates/codex-pr-review-brief.md
+++ b/10-templates/codex-pr-review-brief.md
@@ -4,7 +4,7 @@
 
 ## Role
 
-You are acting as the **Reviewer / Merge Agent — Codex** as defined in `governance.md`.
+You are acting as the **Compliance Officer** as defined in `governance.md`.
 
 You are **not** a co-author and **not** a creative collaborator.  
 You are a **spec-to-implementation auditor**.
@@ -20,7 +20,7 @@ If there is any conflict, ambiguity, or tension:
 
 Review the pull request for **alignment, completeness, and safety** relative to `governance.md`.
 
-Your output must help the CEO/Director answer one question:
+Your output must help the Executive Sponsor / AI Governance Manager answer one question:
 
 > “Does this PR correctly and sufficiently implement the operating model, or does it introduce gaps, drift, or risk?”
 

--- a/10-templates/repo-starters/copilot-instructions.md
+++ b/10-templates/repo-starters/copilot-instructions.md
@@ -1,5 +1,10 @@
 # Copilot Instructions (Template)
 
+## Role Framing (Required)
+- Declare your assigned role before task details (role first, tool second)
+- Treat tools as assignment metadata, not role identity
+- Escalate protected-path approvals to the Executive Sponsor
+
 ## Purpose
 - Define how agents should operate in this repo.
 
@@ -16,6 +21,7 @@
 - docs/ai/context.md
 - docs/ai/architecture.md
 - docs/ai/decisions.md
+- 00-os/role-charters/
 
 ## TODO
 - Add repo-specific do/don't rules.

--- a/10-templates/review-checklists/agent-output-review.md
+++ b/10-templates/review-checklists/agent-output-review.md
@@ -1,4 +1,4 @@
-# Agent Output Review Checklist (Human or Codex)
+# Agent Output Review Checklist (Human or Compliance Officer)
 
 ## Completeness
 - [ ] All requested files created/updated
@@ -18,7 +18,7 @@
 ## Decision
 - [ ] Approve
 - [ ] Request changes (list blockers)
-- [ ] Escalate to CEO (protected changes or boundary shifts)
+- [ ] Escalate to Executive Sponsor (protected changes or boundary shifts)
 
 ## TODO
 - Add any domain-specific review steps.

--- a/10-templates/review-checklists/pr-review.md
+++ b/10-templates/review-checklists/pr-review.md
@@ -1,8 +1,8 @@
 # PR Review Checklist (Deterministic)
 
 ## Blockers (Must Pass)
-- [ ] PR description includes all three exact metadata keys (Primary-Actor:, Reviewed-By:, CEO-Approval:)
-- [ ] At least one role label exists (agent:copilot / agent:codex / role:CEO)
+- [ ] PR description includes all three exact metadata keys (Primary-Role:, Reviewed-By-Role:, Executive-Sponsor-Approval:)
+- [ ] At least one role label exists (role:implementation-specialist / role:compliance-officer / role:ai-governance-manager / role:business-analyst / role:executive-sponsor)
 - [ ] Exactly one status:* label exists
 
 ## Review Gate (Minimum)
@@ -13,13 +13,13 @@
 - [ ] TODOs added where human judgment is required
 
 ## Role Attribution Verification
-- [ ] Commit messages include role prefixes ([Copilot], [Codex], [CEO])
-- [ ] PR title or labels identify the primary actor
-- [ ] CEO approval comment exists when required (protected paths)
+- [ ] Commit messages include role prefixes ([Implementation Specialist], [Compliance Officer], [AI Governance Manager], [Business Analyst], [Executive Sponsor])
+- [ ] PR title or labels identify the primary role
+- [ ] Executive Sponsor approval comment exists when required (protected paths)
 
 ## Protected Changes Logic
-- [ ] If `governance.md`, `context-flow.md`, or `00-os/` changed → CEO approval required
-- [ ] If Plane A/B boundary changes detected → CEO approval required
+- [ ] If `governance.md`, `context-flow.md`, or `00-os/` changed → Executive Sponsor approval required
+- [ ] If Plane A/B boundary changes detected → Executive Sponsor approval required
 
 ## Low-Risk Fast-Track
 - [ ] Only low-risk paths changed (10-templates/, 30-vendor-notes/, new 20-canvases/)
@@ -28,7 +28,7 @@
 ## Outcome
 - [ ] Approve
 - [ ] Request changes (list blockers)
-- [ ] Escalate to CEO
+- [ ] Escalate to Executive Sponsor
 
 ## TODO
 - Add repo-specific gates (tests, lint, etc.).

--- a/10-templates/role-charters/_template-role-charter.md
+++ b/10-templates/role-charters/_template-role-charter.md
@@ -1,0 +1,19 @@
+# <Job Title>
+
+## Role Purpose
+
+## Core Responsibilities
+
+## Explicit Non-Responsibilities
+
+## Decision Rights (Approve / Recommend / Execute / Escalate)
+
+## Escalation Triggers
+
+## Required Inputs and References
+
+## Success Measures
+
+## Assignment Notes (Human/AI occupant + optional tool)
+
+Rule: If any charter conflicts with governance.md, governance.md is authoritative.

--- a/20-canvases/published/_template-publish-log.md
+++ b/20-canvases/published/_template-publish-log.md
@@ -4,6 +4,9 @@
 - Date:
 - Publisher:
 - Source session:
+- Publisher Role (optional):
+- Reviewer Role (optional):
+- Approver Role (optional):
 
 ## Changes Published
 - Item:

--- a/20-canvases/sessions/_template-session-canvas.md
+++ b/20-canvases/sessions/_template-session-canvas.md
@@ -4,6 +4,9 @@
 - Date:
 - Owner:
 - Goal:
+- Role (optional):
+- Actor (optional):
+- Tool (optional):
 
 ## Inputs
 - Vision/priorities

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ These files define the foundation of the system and should change slowly.
 
 - **`context-flow.md`**  
   A visual map of how context, prompts, and artifacts flow between:
-  - CEO (Josh)
-  - Director of AI Context (ChatGPT)
-  - Coding agents  
+  - Executive Sponsor (Josh)
+  - AI Governance Manager (ChatGPT)
+  - Implementation Specialists
   Including how private context becomes public-safe repo context.
 
 ---
@@ -116,12 +116,12 @@ This repository is private by design, but still follows strict rules:
 
 ## How this repo is used in practice
 
-- Josh (CEO) defines goals and constraints
-- ChatGPT (Director of AI Context) helps:
+- The Executive Sponsor (Josh) defines goals and constraints
+- The AI Governance Manager (ChatGPT) helps:
   - design context
   - generate prompts
   - review agent output
-- Agents (Copilot / Codex / Continue) execute using **repo-local, public-safe context**
+- Implementation Specialists (Copilot / Codex / Continue) execute using **repo-local, public-safe context**
 - Durable knowledge always lands in files, not chat logs
 
 ---

--- a/canvas.md
+++ b/canvas.md
@@ -3,12 +3,13 @@
 This canvas captures exploratory context, options, and future-looking ideas.
 
 Authoritative, enforceable policy lives in `governance.md`.
+Ratified role definitions live in `governance.md` and `00-os/role-charters/`.
 
 ---
 
 ## Purpose
 
-This document captures the **durable operating model** for how Josh (CEO), ChatGPT (Director of AI Context), and coding agents (VS Code Copilot / Codex / Continue / future LLMs) collaborate.
+This document captures the **durable operating model** for how the Executive Sponsor (Josh), AI Governance Manager (ChatGPT), and Implementation Specialists (VS Code Copilot / Codex / Continue / future LLMs) collaborate.
 
 The goal is to:
 

--- a/context-flow.md
+++ b/context-flow.md
@@ -1,15 +1,15 @@
 # Context Flow Map
 
-This diagram shows how vision, context, prompts, and artifacts flow between **Josh (CEO)**, **ChatGPT (Director of AI Context)**, and the **coding agents** (VS Code Copilot / Codex / Continue / future LLMs), with **public vs private context planes** and the **canvas lifecycle**.
+This diagram shows how vision, context, prompts, and artifacts flow between the **Executive Sponsor (Josh)**, **AI Governance Manager (ChatGPT)**, and **Implementation Specialists** (VS Code Copilot / Codex / Continue / future LLMs), with **public vs private context planes** and the **canvas lifecycle**.
 
 ```mermaid
 flowchart TB
   %% =========================
   %% Actors
   %% =========================
-  CEO["CEO: Josh<br/>Vision - Priorities - Constraints"]:::actor
-  DIR["Director of AI Context: ChatGPT<br/>Context design - Prompting - Review"]:::actor
-  AGENTS["Agents: Copilot / Codex / Continue<br/>Execution in VS Code"]:::actor
+  CEO["Executive Sponsor: Josh<br/>Vision - Priorities - Constraints"]:::actor
+  DIR["AI Governance Manager: ChatGPT<br/>Context design - Prompting - Review"]:::actor
+  AGENTS["Implementation Specialists: Copilot / Codex / Continue<br/>Execution in VS Code"]:::actor
 
   %% =========================
   %% Context Planes (Stores)

--- a/governance.md
+++ b/governance.md
@@ -8,32 +8,54 @@ For exploratory ideas, options, and future-looking notes, see `canvas.md`.
 
 ## Organizational Model
 
-### CEO — Josh
+### Executive Sponsor — Josh (current assignment)
 
 - Sets vision, priorities, and constraints
 - Decides what becomes public vs private
 - Approves publishable artifacts
 
-### Director of AI Context — ChatGPT
+### AI Governance Manager — ChatGPT (current assignment)
 
 - Helps design and maintain the context system
 - Produces prompts, reviews agent output, and enforces standards
 - Maintains private operational knowledge
 - Prepares sanitized artifacts for publication
 
-### Reviewer / Merge Agent — Codex
+### Compliance Officer — Codex (current assignment)
 
-- Reviews Copilot/agent pull requests for alignment with this operating model
+- Reviews implementation output for alignment with this operating model
 - Checks for security leaks, scope creep, and Plane A vs Plane B violations
 - Uses deterministic checklists (not “looks good” intuition)
-- Recommends approve / request changes; does not merge protected changes without CEO sign-off
+- Recommends approve / request changes; does not merge protected changes without Executive Sponsor sign-off
 - Posts the PR Review Report as a comment on every PR it reviews (required artifact)
 
-### Agents — Copilot / Codex / Continue / Others
+### Implementation Specialist — Copilot / Codex / Continue / Others (current assignments)
 
 - Execute tasks using provided context
 - Operate primarily on repo-local, public-safe context
 - Do not retain long-term memory; context must be supplied
+
+### Business Analyst (proposal and analysis role)
+
+- Performs exploratory analysis and planning
+- Proposes changes and drafts work orders
+- Does not approve protected changes
+
+### Role assignment principle
+
+- Roles define responsibility, authority, and escalation
+- Tools and humans are assignment metadata, not role identity
+- Canonical role charters live in `00-os/role-charters/`
+
+### Legacy role mapping (for reference)
+
+| Legacy reference | Canonical role | Notes |
+|---|---|---|
+| CEO (Josh) | Executive Sponsor | Final approval responsibility for protected changes |
+| Director of AI Context (ChatGPT) | AI Governance Manager | Context-system ownership and curation |
+| Reviewer / Merge Agent — Codex | Compliance Officer | Deterministic compliance review function |
+| Agents (Copilot/Codex/Continue/Others) | Implementation Specialist | Execution role, tool-agnostic |
+| Exploratory analysis / proposal | Business Analyst | Proposal and planning role |
 
 ---
 
@@ -63,7 +85,7 @@ Purpose:
 
 Includes:
 
-- CEO/Director/Agent operating system
+- Executive Sponsor / AI Governance Manager / Implementation Specialist operating system
 - Prompt templates with internal assumptions
 - Unredacted session canvases
 - Tool behavior notes and quirks
@@ -89,13 +111,13 @@ Purpose:
 
 - Subset of the session canvas
 - Explicitly marked as safe for repo inclusion
-- Reviewed by CEO before publication
+- Reviewed by Executive Sponsor before publication
 
 ### 3. Repo Canvas (Public-Safe)
 
 - Added to the target repo under `docs/ai/`
 - Becomes durable context for agents
-- Used by Copilot / Codex / Continue going forward
+- Used by Implementation Specialists (Copilot / Codex / Continue) going forward
 
 **Rule:** Chat history is ephemeral. Canvases are durable.
 
@@ -112,20 +134,20 @@ All meaningful changes in this repo should be **reviewable**. The default workfl
 - Provide a clear contract between agents and reviewers
 
 ### Default workflow
-1. **Create an Issue** (CEO, Director, or Agent) defining: objective, scope, constraints, and definition of done
-2. **Implement on a branch** (agent or human) with focused commits and role-attributed commit messages
+1. **Create an Issue** (Executive Sponsor, AI Governance Manager, Business Analyst, or Implementation Specialist) defining: objective, scope, constraints, and definition of done
+2. **Implement on a branch** (role occupant) with focused commits and role-attributed commit messages
 3. **Open a Pull Request** using templates and checklists, including machine-readable PR metadata (see Role Attribution)
-4. **Apply PR labels** (agent or human) immediately after PR creation via `gh` to self-identify actor and set initial status
+4. **Apply PR labels** (role occupant) immediately after PR creation via `gh` to self-identify role and set initial status
 5. **Review**
 
-   - Codex reviews for compliance (structure, security, scope, Plane A/B boundaries)
-   - Codex posts the PR Review Report as a PR comment on the PR (required)
+   - Compliance Officer reviews for compliance (structure, security, scope, Plane A/B boundaries)
+   - Compliance Officer posts the PR Review Report as a PR comment on the PR (required)
    - Reviewer updates PR labels to reflect outcome (approved / changes requested)
-   - Director/CEO makes final call for sensitive changes
+   - AI Governance Manager / Executive Sponsor makes final call for sensitive changes
 
 6. **Merge** (human merge for protected changes; update status labels)
 
-### Protected changes (require CEO approval)
+### Protected changes (require Executive Sponsor approval)
 
 - `governance.md` and `context-flow.md`
 - Anything under `00-os/` (operating system & guardrails)
@@ -187,15 +209,15 @@ If the branch should be retained, omit the `--delete-branch` flag.
 
 ---
 
-## Role Attribution & Auditability (Humans vs Agents)
+## Role Attribution & Auditability (Humans vs Tools)
 
 Because all GitHub actions are authenticated under the same human identity (`joshphillipssr`), **explicit role attribution is required** to preserve auditability and intent.
 
 The goal is to make it immediately clear:
 
-- Who performed the work (Human vs Copilot vs Codex)
-- Who reviewed it
-- Who approved protected changes
+- Which role performed the work
+- Which role reviewed it
+- Which role approved protected changes
 
 ### Required attribution mechanisms
 
@@ -210,25 +232,27 @@ At least **two** of the following must be used on every Pull Request (and at lea
 
 Use a clear prefix in commit messages:
 
-- `[Copilot]` — work generated or scaffolded by Copilot
-- `[Codex]` — review-driven or corrective changes based on Codex analysis
-- `[CEO]` — human decisions, approvals, or direct edits by Josh
+- `[Implementation Specialist]` — work generated or scaffolded for execution
+- `[Compliance Officer]` — review-driven or corrective changes based on compliance analysis
+- `[AI Governance Manager]` — context-system ownership and curation changes
+- `[Business Analyst]` — proposal or planning artifacts
+- `[Executive Sponsor]` — approval decisions or direct edits by the sponsor
 
 Example:
 
 ```text
-[Copilot] scaffold Context-Engineering templates
-[Codex] fix tier naming inconsistencies
-[CEO] approve protected-path changes
+[Implementation Specialist] scaffold Context-Engineering templates
+[Compliance Officer] fix tier naming inconsistencies
+[Executive Sponsor] approve protected-path changes
 ```
 
 #### 2. Machine-readable PR metadata (required)
 
 Every PR description must include the following fields (exact keys), so humans and automation can parse intent reliably:
 
-- `Primary-Actor: Copilot|Codex|CEO`
-- `Reviewed-By: Codex|CEO|N/A`
-- `CEO-Approval: Required|Not-Required|Provided`
+- `Primary-Role: Executive Sponsor|AI Governance Manager|Compliance Officer|Business Analyst|Implementation Specialist`
+- `Reviewed-By-Role: Compliance Officer|Executive Sponsor|N/A`
+- `Executive-Sponsor-Approval: Required|Not-Required|Provided`
 
 These fields do not replace narrative description; they make attribution auditable.
 
@@ -238,13 +262,15 @@ Labels make role and status visible at a glance and must be applied on every PR.
 
 **Role labels (pick all that apply):**
 
-- `agent:copilot` — work primarily authored/scaffolded by Copilot
-- `agent:codex` — work primarily driven by Codex review/fixes
-- `role:CEO` — human-authored or human-directed changes by Josh
+- `role:executive-sponsor`
+- `role:ai-governance-manager`
+- `role:compliance-officer`
+- `role:business-analyst`
+- `role:implementation-specialist`
 
 **Optional:**
 
-- `role:CEO-approved` — use when a protected-path CEO approval comment exists (redundant but sometimes convenient)
+- `role:executive-sponsor-approved` — use when a protected-path approval comment exists (redundant but sometimes convenient)
 
 **Status labels (pick one current status):**
 
@@ -255,28 +281,28 @@ Labels make role and status visible at a glance and must be applied on every PR.
 - `status:closed`
 - `status:superseded`
 
-**Rule:** Labels should be applied/updated by the actor (Copilot/Codex/CEO) via `gh` as part of the workflow — manual labeling is the exception, not the norm.
+**Rule:** Labels should be applied/updated by the actor (Implementation Specialist / Compliance Officer / Executive Sponsor) via `gh` as part of the workflow — manual labeling is the exception, not the norm.
 
 #### 4. Label application via `gh` (canonical commands)
 
-Agents may have access to a shell with `gh` configured under the CEO identity. When labeling is required, use these canonical commands:
+Agents may have access to a shell with `gh` configured under the Executive Sponsor identity. When labeling is required, use these canonical commands:
 
 Apply initial labels after PR creation (example PR #3):
 
 ```bash
-gh pr edit 3 --add-label "agent:copilot" --add-label "status:needs-review" --remove-label "status:changes-requested" --remove-label "status:approved" --remove-label "status:merged" --remove-label "status:closed" --remove-label "status:superseded"
+gh pr edit 3 --add-label "role:implementation-specialist" --add-label "status:needs-review" --remove-label "status:changes-requested" --remove-label "status:approved" --remove-label "status:merged" --remove-label "status:closed" --remove-label "status:superseded"
 ```
 
-Update labels after Codex review (REQUEST CHANGES):
+Update labels after Compliance Officer review (REQUEST CHANGES):
 
 ```bash
-gh pr edit 3 --add-label "agent:codex" --add-label "status:changes-requested" --remove-label "status:needs-review" --remove-label "status:approved" --remove-label "status:merged" --remove-label "status:closed" --remove-label "status:superseded"
+gh pr edit 3 --add-label "role:compliance-officer" --add-label "status:changes-requested" --remove-label "status:needs-review" --remove-label "status:approved" --remove-label "status:merged" --remove-label "status:closed" --remove-label "status:superseded"
 ```
 
-Update labels after Codex review (APPROVE):
+Update labels after Compliance Officer review (APPROVE):
 
 ```bash
-gh pr edit 3 --add-label "agent:codex" --add-label "status:approved" --remove-label "status:needs-review" --remove-label "status:changes-requested" --remove-label "status:merged" --remove-label "status:closed" --remove-label "status:superseded"
+gh pr edit 3 --add-label "role:compliance-officer" --add-label "status:approved" --remove-label "status:needs-review" --remove-label "status:changes-requested" --remove-label "status:merged" --remove-label "status:closed" --remove-label "status:superseded"
 ```
 
 Post PR Review Report comment (required):
@@ -292,10 +318,10 @@ gh pr edit 3 --add-label "status:merged" --remove-label "status:approved" --remo
 
 #### 5. Explicit PR comments for protected approval
 
-Protected-path changes **must** include an explicit PR comment from the CEO.
+Protected-path changes **must** include an explicit PR comment from the Executive Sponsor.
 
 Example:
-> **CEO approval:**  
+> **Executive Sponsor approval:**  
 > I approve this pull request, including changes under protected paths (`00-os/`), per the Change Management rules defined in `governance.md`.
 
 ### Non-goals
@@ -303,7 +329,7 @@ Example:
 - GitHub author identity is **not** used to infer role
 - Automated bot identities are optional and not required
 - Attribution must be human-readable and reviewable in the PR timeline
-- Long-term, prefer least-privilege tokens or GitHub automation for agent actions (labeling/commenting) even if they run under the CEO identity today
+- Long-term, prefer least-privilege tokens or GitHub automation for agent actions (labeling/commenting) even if they run under the Executive Sponsor identity today
 
 **Rule:** If an auditor cannot tell *who did what and why* from the PR alone, attribution is insufficient.
 


### PR DESCRIPTION
# Summary
- Refactor governance and templates to canonical HR role naming, role-first metadata, and labels
- Add role charter template and canonical role charter set
- Align org/workflow docs and canvas templates to role-first framing

# Issue
- Closes #35

# Machine-Readable Metadata (Required)
Primary-Role: Implementation Specialist
Reviewed-By-Role: N/A
Executive-Sponsor-Approval: Required
