### PR TITLE
Align role-oriented template filenames

### DIFF
--- a/10-templates/agent-prompts/compliance-officer-pr-review-checklist.md
+++ b/10-templates/agent-prompts/compliance-officer-pr-review-checklist.md
@@ -1,8 +1,8 @@
-# Codex PR Review Checklist (Template)
+# Compliance Officer PR Review Checklist (Template)
 
 This file is a checklist + post-review enforcement actions for the Compliance Officer (Codex assignment).
 
-Canonical review brief and required PR Review Report format: `10-templates/codex-pr-review-brief.md` (source of truth: `governance.md`).
+Canonical review brief and required PR Review Report format: `10-templates/compliance-officer-pr-review-brief.md` (source of truth: `governance.md`).
 
 ## PR
 - Link:

--- a/10-templates/agent-prompts/compliance-officer-task-brief.md
+++ b/10-templates/agent-prompts/compliance-officer-task-brief.md
@@ -1,4 +1,4 @@
-# Codex Task Brief (Template)
+# Compliance Officer Task Brief (Template)
 
 ## Role
 - Compliance Officer (deterministic)

--- a/10-templates/agent-prompts/implementation-specialist-task-brief.md
+++ b/10-templates/agent-prompts/implementation-specialist-task-brief.md
@@ -1,4 +1,4 @@
-# Copilot Task Brief (Template)
+# Implementation Specialist Task Brief (Template)
 
 ## Assigned Role
 - Role: Implementation Specialist

--- a/10-templates/agent-work-orders/implementation-specialist-work-order.md
+++ b/10-templates/agent-work-orders/implementation-specialist-work-order.md
@@ -1,4 +1,4 @@
-# Copilot Work Order (Template)
+# Implementation Specialist Work Order (Template)
 
 Use this template in the **body of a GitHub Issue** when the Issue is intended to be executed directly by Copilot (i.e., “tell Copilot the Issue number and get to work”).
 
@@ -6,7 +6,7 @@ Use this template in the **body of a GitHub Issue** when the Issue is intended t
 
 ---
 
-## Copilot Work Order (Authoritative)
+## Implementation Specialist Work Order (Authoritative)
 
 ## Objective
 Describe the single outcome this work order must achieve (1–3 sentences). Keep it measurable.

--- a/10-templates/compliance-officer-pr-review-brief.md
+++ b/10-templates/compliance-officer-pr-review-brief.md
@@ -1,6 +1,6 @@
 
 
-# Codex PR Review Brief — Context-Engineering
+# Compliance Officer PR Review Brief — Context-Engineering
 
 ## Role
 


### PR DESCRIPTION
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required

## Summary
- rename role-oriented templates to canonical role names
- update headings and internal reference to new paths

## Testing
- not run (docs-only changes)

Closes #40