### PR TITLE
Implementation Specialist: Align org-model role wording

### DIFF
--- a/00-os/org-model.md
+++ b/00-os/org-model.md
@@ -11,7 +11,7 @@
   - Designs context system
   - Curates and sanitizes outputs
   - Maintains Plane B assets
-- **Compliance Officer (optional)**
+- **Compliance Officer**
   - Reviews implementation output for alignment with operating model
   - Uses deterministic checklists (no intuition-only approvals)
   - Flags security leaks, scope creep, Plane A/B violations


### PR DESCRIPTION
## Summary
- Remove "(optional)" from the Compliance Officer role heading to match governance.

## Checklist (Acceptance Criteria)
- [x] All changes are strictly within the declared Scope (`00-os/org-model.md`)
- [x] No protected files were modified unless explicitly listed in Scope
- [x] Branch was created via `gh issue develop 14 --checkout`
- [x] No secrets, tokens, internal hostnames, IPs, or personal data introduced
- [x] Commit message starts with `[Implementation Specialist]`
- [x] PR description includes the exact required metadata keys
- [x] PR description includes `Closes #14`
- [ ] PR labels applied via `gh` (`role:implementation-specialist` and one `status:*` label)
- [ ] Executive Sponsor approval comment added (required for protected path)

Primary-Role: Implementation Specialist
Reviewed-By-Role: N/A
Executive-Sponsor-Approval: Required

Closes #14
