### PR TITLE
Make PR label method tool-agnostic

### DIFF
--- a/00-os/workflow.md
+++ b/00-os/workflow.md
@@ -5,7 +5,7 @@
 2. **Branch (required)**: Create from the Issue via `gh issue develop <ISSUE_NUMBER> --checkout`
 3. **Implementation**: Focused edits with minimal scope and role-attributed commit messages
 4. **Pull Request**: Use templates + include machine-readable PR metadata (`Primary-Role` / `Reviewed-By-Role` / `Executive-Sponsor-Approval`) and link/close the Issue (example: `Closes #<ISSUE_NUMBER>`)
-5. **Labels**: Apply required PR labels (at least one `role:*` label + exactly one `status:*` label) via `gh` immediately after PR creation
+5. **Labels**: Apply required PR labels (at least one `role:*` label + exactly one `status:*` label) using GitHub UI, API/automation, or `gh` immediately after PR creation
 6. **Review**: Compliance Officer review + human decision where required; Compliance Officer posts PR Review Report comment; reviewer updates status labels after verdict; AI Governance Manager / Executive Sponsor makes final call for sensitive changes
 7. **Merge**: Human merge for protected changes; update status labels
 

--- a/10-templates/agent-prompts/compliance-officer-pr-review-checklist.md
+++ b/10-templates/agent-prompts/compliance-officer-pr-review-checklist.md
@@ -62,7 +62,7 @@ gh pr comment <PR_NUMBER> --body-file <PATH_TO_PR_REVIEW_REPORT_MD>
 **If PR touches protected paths and an explicit Executive Sponsor approval comment exists**
 - Optionally apply label `role:executive-sponsor-approved`
 
-All label changes must be executed using `gh pr edit`.
+Label changes may be executed using GitHub UI, API/automation, or `gh`. If using `gh`, apply changes with `gh pr edit`.
 
 Compliance Officer (Codex assignment) must request permission before executing shell commands.
 Compliance Officer (Codex assignment) must not merge the PR.

--- a/10-templates/agent-work-orders/implementation-specialist-work-order.md
+++ b/10-templates/agent-work-orders/implementation-specialist-work-order.md
@@ -63,7 +63,7 @@ Use checkboxes. Make these **binary** (pass/fail).
   - `Primary-Role: Implementation Specialist`
   - `Reviewed-By-Role: N/A` (or a canonical role if specified)
   - `Executive-Sponsor-Approval: Not-Required` (or `Required` / `Provided` if protected paths are touched)
-- [ ] PR labels applied via `gh`:
+- [ ] PR labels applied using GitHub UI, API/automation, or `gh`:
   - `role:implementation-specialist`
   - exactly one `status:*` label (`status:needs-review`)
 
@@ -73,7 +73,7 @@ State the exact PR title and any required PR-body summary.
 - Open a PR titled: `Copilot: <short title>`
 - Include a short summary mapping changes to Acceptance Criteria
 - Link and close the Issue in the PR description (example: `Closes #<ISSUE_NUMBER>`)
-- Apply labels using canonical `gh` commands from `governance.md`
+- Apply labels (canonical `gh` commands in `governance.md` are optional examples)
 - Do not merge the PR
 
 ### Branching (Required)

--- a/governance.md
+++ b/governance.md
@@ -151,7 +151,7 @@ All meaningful changes in this repo should be **reviewable**. The default workfl
 2. **Create the branch from the Issue** using `gh issue develop <ISSUE_NUMBER> --checkout` (role occupant)
 3. **Implement on the branch** with focused commits and role-attributed commit messages
 4. **Open a Pull Request** using templates and checklists, including machine-readable PR metadata (see Role Attribution). PR description must link and close the Issue (example: `Closes #<ISSUE_NUMBER>`)
-5. **Apply PR labels** (role occupant) immediately after PR creation via `gh` to self-identify role and set initial status
+5. **Apply PR labels** (role occupant) immediately after PR creation using GitHub UI, API/automation, or `gh` to self-identify role and set initial status
 6. **Review**
 
    - Compliance Officer reviews for compliance (structure, security, scope, Plane A/B boundaries)
@@ -305,7 +305,7 @@ Labels make role and status visible at a glance and must be applied on every PR.
 - `status:closed`
 - `status:superseded`
 
-**Rule:** Labels should be applied/updated by the actor (Implementation Specialist / Compliance Officer / Executive Sponsor) via `gh` as part of the workflow — manual labeling is the exception, not the norm.
+**Rule:** Labels must be applied/updated by the actor (Implementation Specialist / Compliance Officer / Executive Sponsor) using GitHub UI, API/automation, or `gh` as part of the workflow.
 
 #### Legacy terminology treatment (deprecated)
 
@@ -313,7 +313,9 @@ Legacy role terms are allowed only as historical references (for example, in the
 
 If a PR description, comment, or label uses legacy role terms (for example: `CEO`, `Director of AI Context`, `role:CEO`, `CEO-Approval`), reviewers must request changes and require replacement with canonical role terminology.
 
-#### 4. Label application via `gh` (canonical commands)
+#### 4. Label application methods (UI/API/`gh`) with canonical `gh` examples
+
+The allowed methods are GitHub UI, GitHub API/automation, or `gh`. The commands below are optional examples, not exclusive requirements.
 
 Agents may have access to a shell with `gh` configured under the Executive Sponsor identity. When labeling is required, use these canonical commands:
 


### PR DESCRIPTION
## Summary
- allow PR label changes via GitHub UI, API/automation, or Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility`
- keep Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` commands as optional examples

## Testing
- not run (docs only)

Primary-Role: Implementation Specialist
Reviewed-By-Role: N/A
Executive-Sponsor-Approval: Required

Closes #47