### PR TITLE
Add issue/PR triage policy

### DIFF
--- a/00-os/workflow.md
+++ b/00-os/workflow.md
@@ -12,6 +12,12 @@
 ## Required Rules
 - Every PR must map to an existing Issue.
 - Branch creation for Issue work must use `gh issue develop <ISSUE_NUMBER> --checkout` (no manual `git checkout -b`).
+- Issues must define objective, scope, constraints, and definition of done.
+
+## Issue/PR Triage
+- **Blocker**: must be resolved in the current PR before approval/merge.
+- **Follow-up**: create a linked Issue; keep the current PR scoped.
+- **Note**: keep as a note/checklist/comment; no new Issue required unless promoted to follow-up.
 
 ## Protected Changes (Require Executive Sponsor Approval)
 - `governance.md` and `context-flow.md`

--- a/governance.md
+++ b/governance.md
@@ -165,6 +165,15 @@ All meaningful changes in this repo should be **reviewable**. The default workfl
 - Issue-first: every PR maps to an existing Issue.
 - Branch creation for Issue work must use `gh issue develop <ISSUE_NUMBER> --checkout`.
 - No manual `git checkout -b` for Issue-driven PR work.
+- Issues must define objective, scope, constraints, and definition of done.
+
+### Issue/PR triage (blocker vs follow-up vs note)
+
+Use the following triage classes for in-flight findings during Issue/PR work:
+
+- **Blocker:** must be resolved in the current PR before approval/merge.
+- **Follow-up:** create a linked Issue; keep the current PR scoped.
+- **Note:** keep as a note/checklist/comment; no new Issue required unless promoted to follow-up.
 
 **If no Issue exists (fallback sequence):**
 1) `gh issue create ...`


### PR DESCRIPTION
# Summary

- Add blocker/follow-up/note triage policy to governance.
- Mirror issue content requirements and triage in workflow.

# Issue

- Linked issue (must close):
- Closes #9

# Issue-Backed Branching (Required)

- [x] Branch created via `gh issue develop <ISSUE_NUMBER> --checkout`
- [x] PR description links and closes the Issue (example: `Closes #<ISSUE_NUMBER>`)

# Machine-Readable Metadata (Required)

Primary-Role: Implementation Specialist
Reviewed-By-Role: N/A
Executive-Sponsor-Approval: Required

# Role Attribution

- **Primary Role:** Implementation Specialist
- [x] Commit messages include role prefixes ([Executive Sponsor], [AI Governance Manager], [Compliance Officer], [Business Analyst], [Implementation Specialist])
- [ ] At least one role label applied (role:executive-sponsor / role:ai-governance-manager / role:compliance-officer / role:business-analyst / role:implementation-specialist)
- [ ] Exactly one status:* label applied
- [x] No legacy role terms used in metadata/labels (CEO, Director of AI Context, role:CEO, CEO-Approval)
- [ ] Executive Sponsor approval provided (required for protected paths)

# Review Gate (Minimum)

- [x] No secrets, tokens, internal hostnames, or personal data
- [x] No new top-level folders without explicit instruction
- [x] Changes are scoped to the Issue
- [x] Templates/checklists used instead of long prose where applicable
- [x] TODOs added where human judgment is required (not applicable)

# Protected Changes Logic

- [x] `governance.md`, `context-flow.md`, or `00-os/` touched → Executive Sponsor approval required
- [ ] Plane A/B boundary changes detected → Executive Sponsor approval required

# Low-Risk Fast-Track

- [ ] Only low-risk paths changed (10-templates/, 30-vendor-notes/, new 20-canvases/)
- [ ] Review gate passed → eligible for fast-track
