### PR TITLE
Add multi-arch GHCR role workstation images

### DIFF
--- a/.devcontainer-workstation/README.md
+++ b/.devcontainer-workstation/README.md
@@ -61,6 +61,13 @@ Default package names:
 - `ghcr.io/josh-phillips-llc/context-engineering-workstation-implementation-specialist:latest`
 - `ghcr.io/josh-phillips-llc/context-engineering-workstation-compliance-officer:latest`
 
+Verify the published platforms include both `linux/amd64` and `linux/arm64`:
+
+```bash
+docker buildx imagetools inspect ghcr.io/josh-phillips-llc/context-engineering-workstation-implementation-specialist:latest
+docker buildx imagetools inspect ghcr.io/josh-phillips-llc/context-engineering-workstation-compliance-officer:latest
+```
+
 If you exported `GH_TOKEN` for startup bootstrap, clear it after the container is running:
 
 ```bash

--- a/.github/workflows/publish-role-workstation-images.yml
+++ b/.github/workflows/publish-role-workstation-images.yml
@@ -49,6 +49,11 @@ jobs:
           echo "owner=${owner}" >> "$GITHUB_OUTPUT"
           echo "name=${image}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -81,10 +86,25 @@ jobs:
           context: .
           file: .devcontainer-workstation/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             IMAGE_ROLE_PROFILE=${{ matrix.role_profile }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Validate multi-arch manifest
+        run: |
+          set -euo pipefail
+          image="${{ steps.image.outputs.name }}:latest"
+          output="$(docker buildx imagetools inspect "$image")"
+          printf '%s' "$output" | grep -q "linux/amd64"
+          printf '%s' "$output" | grep -q "linux/arm64"
+          {
+            echo "### Manifest validation"
+            echo
+            echo "- Image: \`$image\`"
+            echo "- Platforms: linux/amd64, linux/arm64"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish summary
         run: |


### PR DESCRIPTION
## Summary
- publish role workstation images for linux/amd64 and linux/arm64
- validate multi-arch manifests after push
- document GHCR platform verification steps

## Testing
- Not run (workflow change)

## Issue
Closes #60

Primary-Role: Implementation Specialist
Reviewed-By-Role: N/A
Executive-Sponsor-Approval: Not-Required
