### PR TITLE
Isolate role container state with role-prefixed named volumes

### DIFF
--- a/.devcontainer-workstation/README.md
+++ b/.devcontainer-workstation/README.md
@@ -84,6 +84,9 @@ $COMPOSE_CMD up -d --build
 `down -v` removes all named volumes (including `gh_config`), so GitHub auth, cloned repos, and other persisted container state are reset.
 Codex config is re-seeded from `.devcontainer-workstation/codex/config.toml` when `/root/.codex` is recreated.
 
+Role containers now use role-prefixed named volumes, so running multiple role containers at once does not share `/workspace/Projects` or runtime config state between roles.
+Each role has isolated volumes for workspace data, GitHub auth config, git config, and codex home.
+
 Confirm container is running:
 
 ```bash
@@ -130,7 +133,7 @@ git clone https://github.com/Josh-Phillips-LLC/Context-Engineering.git
 exit
 ```
 
-`gh` auth is persisted in the `gh_config` volume, so this login should not be required every time.
+`gh` auth is persisted in each role's role-prefixed gh config volume, so this login should not be required every time for that role.
 
 ## 3) Attach VS Code to running container
 

--- a/.devcontainer-workstation/README.md
+++ b/.devcontainer-workstation/README.md
@@ -81,7 +81,7 @@ $COMPOSE_CMD down -v
 $COMPOSE_CMD up -d --build
 ```
 
-`down -v` removes all named volumes (including `gh_config`), so GitHub auth, cloned repos, and other persisted container state are reset.
+`down -v` removes all role-prefixed named volumes (for example, `implementation_gh_config` and `compliance_gh_config`), so GitHub auth, cloned repos, and other persisted container state are reset.
 Codex config is re-seeded from `.devcontainer-workstation/codex/config.toml` when `/root/.codex` is recreated.
 
 Role containers now use role-prefixed named volumes, so running multiple role containers at once does not share `/workspace/Projects` or runtime config state between roles.

--- a/.devcontainer-workstation/docker-compose.ghcr.yml
+++ b/.devcontainer-workstation/docker-compose.ghcr.yml
@@ -4,10 +4,10 @@ services:
     container_name: implementation-workstation
     pull_policy: always
     volumes:
-      - projects_data:/workspace/Projects
-      - gh_config:/root/.config/gh
-      - git_config:/root/.config/git
-      - codex_home:/root/.codex
+      - implementation_projects_data:/workspace/Projects
+      - implementation_gh_config:/root/.config/gh
+      - implementation_git_config:/root/.config/git
+      - implementation_codex_home:/root/.codex
     environment:
       - GH_TOKEN=${GH_TOKEN:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -32,10 +32,10 @@ services:
     profiles:
       - compliance-officer
     volumes:
-      - projects_data:/workspace/Projects
-      - gh_config:/root/.config/gh
-      - git_config:/root/.config/git
-      - codex_home_compliance:/root/.codex
+      - compliance_projects_data:/workspace/Projects
+      - compliance_gh_config:/root/.config/gh
+      - compliance_git_config:/root/.config/git
+      - compliance_codex_home:/root/.codex
     environment:
       - GH_TOKEN=${GH_TOKEN:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -54,8 +54,11 @@ services:
     command: ["sleep", "infinity"]
 
 volumes:
-  projects_data:
-  gh_config:
-  git_config:
-  codex_home:
-  codex_home_compliance:
+  implementation_projects_data:
+  implementation_gh_config:
+  implementation_git_config:
+  implementation_codex_home:
+  compliance_projects_data:
+  compliance_gh_config:
+  compliance_git_config:
+  compliance_codex_home:

--- a/.devcontainer-workstation/docker-compose.yml
+++ b/.devcontainer-workstation/docker-compose.yml
@@ -7,11 +7,11 @@ services:
         IMAGE_ROLE_PROFILE: implementation-specialist
     container_name: implementation-workstation
     volumes:
-      - projects_data:/workspace/Projects
-      - gh_config:/root/.config/gh
-      - git_config:/root/.config/git
+      - implementation_projects_data:/workspace/Projects
+      - implementation_gh_config:/root/.config/gh
+      - implementation_git_config:/root/.config/git
       # - ssh_data:/root/.ssh
-      - codex_home:/root/.codex
+      - implementation_codex_home:/root/.codex
       # Optional: forward host SSH agent into container for commit signing.
       # Set HOST_SSH_AGENT_SOCK before compose up.
       # - type: bind
@@ -46,11 +46,11 @@ services:
     profiles:
       - compliance-officer
     volumes:
-      - projects_data:/workspace/Projects
-      - gh_config:/root/.config/gh
-      - git_config:/root/.config/git
+      - compliance_projects_data:/workspace/Projects
+      - compliance_gh_config:/root/.config/gh
+      - compliance_git_config:/root/.config/git
       # - ssh_data:/root/.ssh
-      - codex_home_compliance:/root/.codex
+      - compliance_codex_home:/root/.codex
       # Optional: forward host SSH agent into container for commit signing.
       # Set HOST_SSH_AGENT_SOCK before compose up.
       # - type: bind
@@ -76,9 +76,12 @@ services:
     command: ["sleep", "infinity"]
 
 volumes:
-  projects_data:
-  gh_config:
-  git_config:
+  implementation_projects_data:
+  implementation_gh_config:
+  implementation_git_config:
+  implementation_codex_home:
+  compliance_projects_data:
+  compliance_gh_config:
+  compliance_git_config:
+  compliance_codex_home:
   # ssh_data:
-  codex_home:
-  codex_home_compliance:


### PR DESCRIPTION
## Summary
- use role-prefixed named volumes for both role containers in local compose and GHCR compose
- isolate workspace, gh config, git config, and codex home per role
- update workstation README to document role-isolated volume behavior

## Why
Running implementation and compliance containers concurrently previously shared `/workspace/Projects` and some config volumes, causing role runtime files to overwrite each other.

## Validation
- compose config parse for both files:
  - `docker-compose -f .devcontainer-workstation/docker-compose.yml --profile compliance-officer config`
  - `docker-compose -f .devcontainer-workstation/docker-compose.ghcr.yml --profile compliance-officer config`
- concurrent runtime check:
  - start implementation + compliance containers together
  - write `ROLE_MARKER.txt` in implementation workspace
  - confirm marker is **not present** in compliance workspace (`NOT_FOUND`)
- confirmed role-prefixed volumes created for both roles via `docker volume ls`

## Role Attribution
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required

Closes #64
