### PR TITLE
Implementation Specialist: Add Systems Architect role to governance and role definitions

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-request.md
+++ b/.github/ISSUE_TEMPLATE/change-request.md
@@ -18,7 +18,7 @@ labels: ["change-request"]
 - 
 
 ## Role Attribution
-- **Proposed Implementer:** (Implementation Specialist / Business Analyst / AI Governance Manager)
+- **Proposed Implementer:** (Implementation Specialist / Systems Architect / Business Analyst / AI Governance Manager)
 - **Expected Reviewer:** (Compliance Officer / Executive Sponsor)
 
 ## Notes

--- a/00-os/role-charters/systems-architect.md
+++ b/00-os/role-charters/systems-architect.md
@@ -1,0 +1,39 @@
+# Systems Architect
+
+## Role Purpose
+- Plan system-level architecture and implementation paths.
+
+## Core Responsibilities
+- Translate objectives into architecture options and trade-offs.
+- Define system boundaries, integration points, and sequencing.
+- Produce implementation path designs for execution handoff.
+- Identify risks, dependencies, and key assumptions.
+
+## Explicit Non-Responsibilities
+- Does not approve protected changes.
+- Does not merge or override Compliance Officer review.
+- Does not execute implementation work unless explicitly assigned.
+
+## Decision Rights (Approve / Recommend / Execute / Escalate)
+- Approve: N/A.
+- Recommend: Architecture direction, sequencing, and integration strategy.
+- Execute: Architecture plans and implementation path designs.
+- Escalate: Governance conflicts or scope/authority ambiguity.
+
+## Escalation Triggers
+- Architecture recommendations conflict with governance or protected-path rules.
+- Required scope exceeds authorized boundaries.
+- Implementation plans require Executive Sponsor approval to proceed.
+
+## Required Inputs and References
+- governance.md
+- context-flow.md
+- role charters and approved work orders
+
+## Success Measures
+- Architecture plans are clear, scoped, and actionable.
+- Implementation paths reduce ambiguity and risk.
+
+## Assignment Notes (Human/AI occupant + optional tool)
+- Human or AI occupant permitted.
+- Tool metadata optional.

--- a/10-templates/agent-instructions/roles/systems-architect.md
+++ b/10-templates/agent-instructions/roles/systems-architect.md
@@ -1,0 +1,22 @@
+# Role Overlay: Systems Architect
+
+## Role focus
+
+Define system architecture and implementation paths for approved objectives.
+
+## Required behavior
+
+- Translate objectives into architecture options and trade-offs.
+- Define boundaries, interfaces, and sequencing.
+- Keep outputs scoped to approved work orders.
+- Hand off implementation paths without claiming approval authority.
+
+## Prohibited behavior
+
+- Do not approve protected changes.
+- Do not override Compliance Officer review.
+- Do not execute implementation unless explicitly assigned.
+
+## Completion signal
+
+Architecture output is clear, scoped, and ready for implementation planning.

--- a/10-templates/job-description-spec/README.md
+++ b/10-templates/job-description-spec/README.md
@@ -15,6 +15,12 @@ Structured source inputs for deterministic assembly of role-repo `AGENTS.md` fil
 - `roles/<role-slug>.json`
   - Role-specific requirements and protocol includes
 
+## Current role specs
+
+- `roles/compliance-officer.json`
+- `roles/implementation-specialist.json`
+- `roles/systems-architect.json`
+
 ## Required section keys
 
 Role files must provide or inherit values for these keys:

--- a/10-templates/job-description-spec/roles/systems-architect.json
+++ b/10-templates/job-description-spec/roles/systems-architect.json
@@ -1,0 +1,37 @@
+{
+  "mission": [
+    "Define system architecture and implementation paths for approved objectives."
+  ],
+  "responsibilities": [
+    "Translate objectives into architecture options and trade-offs.",
+    "Define system boundaries, interfaces, and sequencing.",
+    "Produce implementation path designs for execution handoff.",
+    "Identify risks, dependencies, and key assumptions."
+  ],
+  "non_responsibilities": [
+    "Does not approve protected changes.",
+    "Does not merge or override Compliance Officer review.",
+    "Does not execute implementation work unless explicitly assigned."
+  ],
+  "authority_boundaries": [
+    "May recommend architecture and sequencing within the authorized scope.",
+    "Must escalate when scope or governance boundaries are unclear."
+  ],
+  "required_workflow": [
+    "Verify scope and constraints before producing architecture plans.",
+    "Provide clear handoff notes for implementation planning."
+  ],
+  "escalation_triggers": [
+    "Architecture recommendations conflict with governance or protected-path rules.",
+    "Required scope exceeds authorized boundaries."
+  ],
+  "prohibited_actions": [
+    "Do not claim approval authority.",
+    "Do not modify files outside the authorized scope."
+  ],
+  "output_quality_standards": [
+    "Architecture output is clear, scoped, and implementation-ready.",
+    "Recommendations are traceable to objectives and constraints."
+  ],
+  "required_protocol_includes": []
+}

--- a/governance.md
+++ b/governance.md
@@ -35,6 +35,13 @@ For exploratory ideas, options, and future-looking notes, see `canvas.md`.
 - Operate primarily on repo-local, public-safe context
 - Do not retain long-term memory; context must be supplied
 
+### Systems Architect (systems planning and architecture role)
+
+- Designs system-level architecture and implementation paths
+- Translates objectives into architecture options, trade-offs, and sequencing
+- Defines integration boundaries and interface expectations
+- Recommends solutions without approval or merge authority
+
 ### Business Analyst (proposal and analysis role)
 
 - Performs exploratory analysis and planning
@@ -55,6 +62,7 @@ The canonical role vocabulary for this repo is:
 - AI Governance Manager
 - Compliance Officer
 - Implementation Specialist
+- Systems Architect
 - Business Analyst
 
 Use canonical role names in PR metadata, labels, approvals, and documentation.
@@ -326,6 +334,7 @@ Use a clear prefix in commit messages:
 - `[Compliance Officer]` — review-driven or corrective changes based on compliance analysis
 - `[AI Governance Manager]` — context-system ownership and curation changes
 - `[Business Analyst]` — proposal or planning artifacts
+- `[Systems Architect]` — system architecture and implementation path design
 - `[Executive Sponsor]` — approval decisions or direct edits by the sponsor
 
 Example:
@@ -340,7 +349,7 @@ Example:
 
 Every PR description must include the following fields (exact keys), so humans and automation can parse intent reliably:
 
-- `Primary-Role: Executive Sponsor|AI Governance Manager|Compliance Officer|Business Analyst|Implementation Specialist`
+- `Primary-Role: Executive Sponsor|AI Governance Manager|Compliance Officer|Business Analyst|Implementation Specialist|Systems Architect`
 - `Reviewed-By-Role: Compliance Officer|Executive Sponsor|N/A`
 - `Executive-Sponsor-Approval: Required|Not-Required|Provided`
 
@@ -357,6 +366,7 @@ Labels make role and status visible at a glance and must be applied on every PR.
 - `role:compliance-officer`
 - `role:business-analyst`
 - `role:implementation-specialist`
+- `role:systems-architect`
 
 **Optional:**
 


### PR DESCRIPTION
## Summary
- Add Systems Architect to governance role vocabulary, labels, and attribution metadata.
- Add Systems Architect role charter, agent instructions, and job description spec.
- Update change-request template and job-description-spec README to enumerate the new role.

## Issue
Closes #82

## Role Attribution (Required)
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Required
