### PR TITLE
Implementation Specialist: Add systems-architect role container/runtime wiring

### DIFF
--- a/.devcontainer-workstation/README.md
+++ b/.devcontainer-workstation/README.md
@@ -5,6 +5,7 @@ It supports role-scoped startup for:
 
 - `implementation-workstation` (default `Implementation Specialist` profile)
 - `compliance-workstation` (`Compliance Officer` profile)
+- `systems-architect-workstation` (`Systems Architect` profile)
 
 ## 1) Build and start from host
 
@@ -31,6 +32,9 @@ $COMPOSE_CMD up -d --build implementation-workstation
 
 # Optional: Compliance Officer role-scoped container
 # $COMPOSE_CMD --profile compliance-officer up -d --build compliance-workstation
+
+# Optional: Systems Architect role-scoped container
+# $COMPOSE_CMD --profile systems-architect up -d --build systems-architect-workstation
 ```
 
 ## 1a) Start from published GHCR role packages
@@ -55,12 +59,14 @@ $COMPOSE_CMD -f docker-compose.ghcr.yml down
 $COMPOSE_CMD -f docker-compose.ghcr.yml up -d implementation-workstation
 # Optional:
 # $COMPOSE_CMD -f docker-compose.ghcr.yml --profile compliance-officer up -d compliance-workstation
+# $COMPOSE_CMD -f docker-compose.ghcr.yml --profile systems-architect up -d systems-architect-workstation
 ```
 
 Default package names:
 
 - `ghcr.io/josh-phillips-llc/context-engineering-workstation-implementation-specialist:latest`
 - `ghcr.io/josh-phillips-llc/context-engineering-workstation-compliance-officer:latest`
+- `ghcr.io/josh-phillips-llc/context-engineering-workstation-systems-architect:latest`
 
 Release naming and versioning conventions:
 
@@ -76,6 +82,7 @@ Verify the published platforms include both `linux/amd64` and `linux/arm64`:
 ```bash
 docker buildx imagetools inspect ghcr.io/josh-phillips-llc/context-engineering-workstation-implementation-specialist:latest
 docker buildx imagetools inspect ghcr.io/josh-phillips-llc/context-engineering-workstation-compliance-officer:latest
+docker buildx imagetools inspect ghcr.io/josh-phillips-llc/context-engineering-workstation-systems-architect:latest
 ```
 
 If you exported `GH_TOKEN` for startup bootstrap, clear it after the container is running:
@@ -123,12 +130,16 @@ On container startup, each role container auto-clones its role repo by default:
 - `compliance-workstation`
   - URL: `https://github.com/Josh-Phillips-LLC/context-engineering-role-compliance-officer.git`
   - Path: `/workspace/Projects/context-engineering-role-compliance-officer`
+- `systems-architect-workstation`
+  - URL: `https://github.com/Josh-Phillips-LLC/context-engineering-role-systems-architect.git`
+  - Path: `/workspace/Projects/context-engineering-role-systems-architect`
 
 Verify clone status:
 
 ```bash
 docker exec -it implementation-workstation bash -lc 'ls -la /workspace/Projects/context-engineering-role-implementation-specialist'
 docker exec -it compliance-workstation bash -lc 'ls -la /workspace/Projects/context-engineering-role-compliance-officer'
+docker exec -it systems-architect-workstation bash -lc 'ls -la /workspace/Projects/context-engineering-role-systems-architect'
 ```
 
 If auto-clone failed, run manual PAT auth and clone inside the container:
@@ -153,8 +164,10 @@ If needed, you can override default role repo targets with:
 
 - `IMPLEMENTATION_WORKSPACE_REPO_URL`
 - `COMPLIANCE_WORKSPACE_REPO_URL`
+- `SYSTEMS_ARCHITECT_WORKSPACE_REPO_URL`
 - `IMPLEMENTATION_WORKSPACE_REPO_DIR_NAME`
 - `COMPLIANCE_WORKSPACE_REPO_DIR_NAME`
+- `SYSTEMS_ARCHITECT_WORKSPACE_REPO_DIR_NAME`
 
 ## 3) Attach VS Code to running container
 
@@ -162,10 +175,11 @@ In local (non-containerized) VS Code:
 
 1. Open Command Palette
 2. Run `Dev Containers: Attach to Running Container...`
-3. Select `implementation-workstation` or `compliance-workstation`
+3. Select `implementation-workstation`, `compliance-workstation`, or `systems-architect-workstation`
 4. Open folder matching the role container:
    - `/workspace/Projects/context-engineering-role-implementation-specialist`
    - `/workspace/Projects/context-engineering-role-compliance-officer`
+  - `/workspace/Projects/context-engineering-role-systems-architect`
 
 ## 4) Codex config defaults
 

--- a/.devcontainer-workstation/codex/role-profiles/README.md
+++ b/.devcontainer-workstation/codex/role-profiles/README.md
@@ -25,6 +25,7 @@ Startup behavior:
 - Default runtime clone targets are role repos by role:
   - `context-engineering-role-implementation-specialist`
   - `context-engineering-role-compliance-officer`
+  - `context-engineering-role-systems-architect`
 - Runtime adapter instruction files are generated at `/workspace/instructions/AGENTS.md` and `/workspace/instructions/copilot-instructions.md`.
 - VS Code chat defaults are ensured at `/workspace/settings/vscode/settings.json`.
 - Compliance Officer runtime instructions include `10-templates/compliance-officer-pr-review-brief.md` (or image fallback) as a required protocol include.

--- a/.devcontainer-workstation/codex/role-profiles/systems-architect.env
+++ b/.devcontainer-workstation/codex/role-profiles/systems-architect.env
@@ -1,0 +1,6 @@
+# Role overlay for systems planning and architecture work.
+ROLE_APPROVAL_POLICY="on-request"
+ROLE_MODEL_REASONING_EFFORT="high"
+ROLE_MODEL_PERSONALITY="pragmatic"
+ROLE_WRITABLE_ROOTS='["/workspace/Projects"]'
+ROLE_PROJECT_DOC_FALLBACK_FILENAMES='["AGENTS.md", "copilot-instructions.md", ".role.instructions.md", "instructions.md"]'

--- a/.devcontainer-workstation/docker-compose.ghcr.yml
+++ b/.devcontainer-workstation/docker-compose.ghcr.yml
@@ -55,6 +55,35 @@ services:
     entrypoint: ["/usr/local/bin/init-workstation.sh"]
     command: ["sleep", "infinity"]
 
+  systems-architect-workstation:
+    image: ghcr.io/${GHCR_OWNER:-josh-phillips-llc}/${GHCR_IMAGE_PREFIX:-context-engineering-workstation}-systems-architect:${GHCR_IMAGE_TAG:-latest}
+    container_name: systems-architect-workstation
+    pull_policy: always
+    profiles:
+      - systems-architect
+    volumes:
+      - systems_architect_projects_data:/workspace
+      - systems_architect_gh_config:/root/.config/gh
+      - systems_architect_git_config:/root/.config/git
+      - systems_architect_codex_home:/root/.codex
+    environment:
+      - GH_TOKEN=${GH_TOKEN:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - WORKSTATION_DEBUG=${WORKSTATION_DEBUG:-false}
+      - CODEX_HOME=/root/.codex
+      - ROLE_PROFILE=systems-architect
+      - WORKSPACE_REPO_OWNER=${WORKSPACE_REPO_OWNER:-Josh-Phillips-LLC}
+      - WORKSPACE_REPO_URL=${SYSTEMS_ARCHITECT_WORKSPACE_REPO_URL:-https://github.com/Josh-Phillips-LLC/context-engineering-role-systems-architect.git}
+      - WORKSPACE_REPO_DIR=/workspace/Projects/${SYSTEMS_ARCHITECT_WORKSPACE_REPO_DIR_NAME:-context-engineering-role-systems-architect}
+      - AUTO_CLONE_WORKSPACE_REPO=${AUTO_CLONE_WORKSPACE_REPO:-true}
+
+    cap_add:
+      - ALL
+    privileged: true
+    init: true
+    entrypoint: ["/usr/local/bin/init-workstation.sh"]
+    command: ["sleep", "infinity"]
+
 volumes:
   implementation_projects_data:
   implementation_gh_config:
@@ -64,3 +93,7 @@ volumes:
   compliance_gh_config:
   compliance_git_config:
   compliance_codex_home:
+  systems_architect_projects_data:
+  systems_architect_gh_config:
+  systems_architect_git_config:
+  systems_architect_codex_home:

--- a/.devcontainer-workstation/docker-compose.yml
+++ b/.devcontainer-workstation/docker-compose.yml
@@ -77,6 +77,46 @@ services:
     entrypoint: ["/usr/local/bin/init-workstation.sh"]
     command: ["sleep", "infinity"]
 
+  systems-architect-workstation:
+    build:
+      context: ..
+      dockerfile: .devcontainer-workstation/Dockerfile
+      args:
+        IMAGE_ROLE_PROFILE: systems-architect
+    container_name: systems-architect-workstation
+    profiles:
+      - systems-architect
+    volumes:
+      - systems_architect_projects_data:/workspace
+      - systems_architect_gh_config:/root/.config/gh
+      - systems_architect_git_config:/root/.config/git
+      # - ssh_data:/root/.ssh
+      - systems_architect_codex_home:/root/.codex
+      # Optional: forward host SSH agent into container for commit signing.
+      # Set HOST_SSH_AGENT_SOCK before compose up.
+      # - type: bind
+      #  source: ${HOST_SSH_AGENT_SOCK:-/tmp/codex-no-ssh-agent}
+      #  target: /ssh-agent
+    environment:
+      - GH_TOKEN=${GH_TOKEN:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - WORKSTATION_DEBUG=${WORKSTATION_DEBUG:-false}
+      - CODEX_HOME=/root/.codex
+      # - SSH_AUTH_SOCK=/ssh-agent
+      - ROLE_PROFILE=systems-architect
+      - WORKSPACE_REPO_OWNER=${WORKSPACE_REPO_OWNER:-Josh-Phillips-LLC}
+      - WORKSPACE_REPO_URL=${SYSTEMS_ARCHITECT_WORKSPACE_REPO_URL:-https://github.com/Josh-Phillips-LLC/context-engineering-role-systems-architect.git}
+      - WORKSPACE_REPO_DIR=/workspace/Projects/${SYSTEMS_ARCHITECT_WORKSPACE_REPO_DIR_NAME:-context-engineering-role-systems-architect}
+      - AUTO_CLONE_WORKSPACE_REPO=${AUTO_CLONE_WORKSPACE_REPO:-true}
+
+    # Testing-mode autonomy
+    cap_add:
+      - ALL
+    privileged: true
+    init: true
+    entrypoint: ["/usr/local/bin/init-workstation.sh"]
+    command: ["sleep", "infinity"]
+
 volumes:
   implementation_projects_data:
   implementation_gh_config:
@@ -86,4 +126,8 @@ volumes:
   compliance_gh_config:
   compliance_git_config:
   compliance_codex_home:
+  systems_architect_projects_data:
+  systems_architect_gh_config:
+  systems_architect_git_config:
+  systems_architect_codex_home:
   # ssh_data:

--- a/.github/workflows/publish-role-workstation-images.yml
+++ b/.github/workflows/publish-role-workstation-images.yml
@@ -28,6 +28,9 @@ jobs:
           - role_profile: compliance-officer
             image_suffix: compliance-officer
             role_repo: context-engineering-role-compliance-officer
+          - role_profile: systems-architect
+            image_suffix: systems-architect
+            role_repo: context-engineering-role-systems-architect
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-role-repos.yml
+++ b/.github/workflows/sync-role-repos.yml
@@ -26,6 +26,7 @@ on:
           - all
           - implementation-specialist
           - compliance-officer
+          - systems-architect
       owner:
         description: Optional GitHub owner override
         required: false
@@ -59,6 +60,8 @@ jobs:
             repo_name: context-engineering-role-implementation-specialist
           - role_slug: compliance-officer
             repo_name: context-engineering-role-compliance-officer
+          - role_slug: systems-architect
+            repo_name: context-engineering-role-systems-architect
 
     env:
       GH_TOKEN: ${{ secrets.ROLE_REPO_SYNC_TOKEN }}

--- a/10-templates/repo-starters/role-repo-template/README.md
+++ b/10-templates/repo-starters/role-repo-template/README.md
@@ -174,6 +174,7 @@ Behavior:
 - Syncs matrix roles:
   - `implementation-specialist`
   - `compliance-officer`
+  - `systems-architect`
 
 Required secret:
 
@@ -199,6 +200,7 @@ Behavior:
 - Pulls role-repo `AGENTS.md` from:
   - `context-engineering-role-implementation-specialist`
   - `context-engineering-role-compliance-officer`
+  - `context-engineering-role-systems-architect`
 - Bakes role-repo `AGENTS.md` into `/etc/codex/runtime-role-instructions/<role>.md`.
 - Falls back to Context-Engineering instruction sources only when role-repo artifacts are unavailable in build context.
 


### PR DESCRIPTION
## Summary
- Add systems-architect to sync and publish workflow matrices (automation wiring).
- Add systems-architect role profile and compose services (local + GHCR) with role-prefixed volumes and default role repo targets.
- Update workstation and role-repo template docs with systems-architect startup and naming guidance.

## Acceptance Criteria Mapping
- Only files in Scope changed: workflows, devcontainer compose/docs, role profile, role-repo template README.
- New role profile file: .devcontainer-workstation/codex/role-profiles/systems-architect.env.
- sync-role-repos.yml includes systems-architect in matrix and workflow_dispatch.
- publish-role-workstation-images.yml includes systems-architect matrix entry.
- Local and GHCR compose include systems-architect-workstation service with role-prefixed volumes and correct role-repo clone target.
- README docs updated for systems-architect startup and naming guidance.

## Issue
Closes #85

## Role Attribution (Required)
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required
