### PR TITLE
Implementation Specialist: Add governed role-creation templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/role-creation-request.md
+++ b/.github/ISSUE_TEMPLATE/role-creation-request.md
@@ -1,0 +1,46 @@
+---
+name: Role Creation Request
+about: Create a new governed role from charter through role repo and container publication
+labels: ["change-request"]
+---
+
+## Objective
+-
+
+## Required Inputs
+- Role title:
+- Role slug (kebab-case):
+- Role repo owner (organization/user):
+- Role repo name override (optional, default `context-engineering-role-<role-slug>`):
+
+## Scope (Allowed Changes)
+- In scope:
+- Out of scope:
+
+## Implementation Requirements
+- [ ] Create role charter at `00-os/role-charters/<role-slug>.md`
+- [ ] Create role instruction source at `10-templates/agent-instructions/roles/<role-slug>.md`
+- [ ] Create role job-description spec at `10-templates/job-description-spec/roles/<role-slug>.json`
+- [ ] Add role profile env at `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
+- [ ] Wire role in `.devcontainer-workstation/docker-compose.yml`
+- [ ] Wire role in `.devcontainer-workstation/docker-compose.ghcr.yml`
+- [ ] Add role to `.github/workflows/sync-role-repos.yml` matrix
+- [ ] Add role to `.github/workflows/publish-role-workstation-images.yml` matrix
+- [ ] Create public role repo scaffold via `create-public-role-repo.sh`
+- [ ] Verify sync workflow success for the new role
+- [ ] Verify publish workflow success for the new role
+- [ ] Capture workflow/container verification evidence in PR
+
+## Definition of Done
+-
+
+## Role Attribution
+- **Proposed Implementer:** Implementation Specialist
+- **Expected Reviewer:** Compliance Officer
+- **Executive Sponsor Approval:** (Required / Not-Required)
+
+## Notes
+-
+
+## Reference Template
+Use: `10-templates/agent-work-orders/role-creation-work-order.md`

--- a/00-os/workflow.md
+++ b/00-os/workflow.md
@@ -37,6 +37,11 @@
 ## Artifact Flow
 - Session Canvas → Publishable Extract → Repo Canvas
 
+## Role Creation Workflow
+- Canonical execution template: `10-templates/agent-work-orders/role-creation-work-order.md`
+- GitHub issue launcher: `.github/ISSUE_TEMPLATE/role-creation-request.md`
+- Use this pair for end-to-end role rollout work (charter and source definitions through role-repo sync and container publish verification).
+
 ## TODO
 - Add release cadence (weekly/monthly) if needed.
 - Define acceptance criteria for each artifact type.

--- a/10-templates/agent-work-orders/role-creation-work-order.md
+++ b/10-templates/agent-work-orders/role-creation-work-order.md
@@ -1,0 +1,176 @@
+# Role Creation Work Order (Template)
+
+Use this template in the **body of a GitHub Issue** when the Issue is intended to execute a full, governed role rollout from definition through role-repo and container validation.
+
+**Rule:** Section headings in this template are **normative**. Do not rename them.
+
+---
+
+## Implementation Specialist Work Order (Authoritative)
+
+## Objective
+Describe the single role-creation outcome (1-3 sentences). Keep it measurable.
+
+## Scope (Allowed Changes)
+List the **only** files/folders the Implementation Specialist may modify for this role rollout.
+
+- The Implementation Specialist may ONLY modify:
+  - `00-os/role-charters/<role-slug>.md`
+  - `10-templates/agent-instructions/roles/<role-slug>.md`
+  - `10-templates/job-description-spec/roles/<role-slug>.json`
+  - `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
+  - `.devcontainer-workstation/docker-compose.yml`
+  - `.devcontainer-workstation/docker-compose.ghcr.yml`
+  - `.github/workflows/sync-role-repos.yml`
+  - `.github/workflows/publish-role-workstation-images.yml`
+  - `10-templates/repo-starters/role-repo-template/**` (only if template source changes are explicitly required)
+  - Any additional files explicitly listed below for this role
+
+State whether new files may be created (default: **Yes**, only those implied by the listed paths and role slug).
+
+The Implementation Specialist must not infer additional scope beyond what is explicitly listed here.
+
+## Out of Scope
+List explicit exclusions so scope does not expand.
+
+- Any file not listed in Scope
+- Protected artifacts unless explicitly included:
+  - `governance.md`
+  - `context-flow.md`
+  - `00-os/**` files other than the role charter in Scope
+- Unrelated refactors or formatting-only edits
+- Runtime behavior changes unrelated to adding the new role
+- Merging PRs
+
+The Implementation Specialist must not modify any file/path not explicitly listed in Scope.
+
+## Required Inputs
+Fill in all placeholders before execution.
+
+- Role title: `<Role Title>`
+- Role slug (kebab-case): `<role-slug>`
+- Role repo owner: `<github-owner>`
+- Role repo name (default): `context-engineering-role-<role-slug>`
+- Role workstation service name: `<role-slug>-workstation`
+- Role profile env file: `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
+
+## Implementation Requirements
+Provide deterministic edits and execution steps.
+
+### 1) Create role charter (governed role definition)
+- File: `00-os/role-charters/<role-slug>.md`
+- Source scaffold: `10-templates/role-charters/_template-role-charter.md`
+- Ensure the charter explicitly defines:
+  - Role purpose
+  - Core responsibilities
+  - Explicit non-responsibilities
+  - Decision rights
+  - Escalation triggers
+  - Required inputs/references
+  - Success measures
+
+### 2) Create role instruction source
+- File: `10-templates/agent-instructions/roles/<role-slug>.md`
+- Align with `10-templates/agent-instructions/base.md`
+- Include role-specific operating boundaries and escalation rules derived from charter/governance.
+
+### 3) Create role job-description spec
+- File: `10-templates/job-description-spec/roles/<role-slug>.json`
+- Must satisfy required schema/sections used by:
+  - `10-templates/repo-starters/role-repo-template/scripts/build-agent-job-description.py`
+- Ensure generated `AGENTS.md` can be assembled without manual edits.
+
+### 4) Wire workstation runtime for role
+- Add role profile env:
+  - `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
+- Add role service/profile entries in:
+  - `.devcontainer-workstation/docker-compose.yml`
+  - `.devcontainer-workstation/docker-compose.ghcr.yml`
+
+### 5) Add role to sync/publish workflow matrices
+- Update role matrix entries in:
+  - `.github/workflows/sync-role-repos.yml`
+  - `.github/workflows/publish-role-workstation-images.yml`
+- Ensure role repo naming is consistent (`context-engineering-role-<role-slug>`).
+
+### 6) Create public role repo and initial scaffold
+Run:
+```bash
+10-templates/repo-starters/role-repo-template/scripts/create-public-role-repo.sh \
+  --role-slug <role-slug> \
+  --owner <github-owner>
+```
+
+### 7) Verify sync automation and role-repo PR
+Run sync workflow (manual or push-triggered) and verify:
+- Role sync job succeeds
+- Sync PR exists in role repo from `sync/role-repo/<role-slug>` to `main`
+- Managed artifacts updated:
+  - `AGENTS.md`
+  - `.github/copilot-instructions.md`
+  - `.vscode/settings.json`
+  - `README.md`
+
+### 8) Verify image publish and container usability
+Run publish workflow and verify role job succeeds.
+Validate published image pull/run for the new role profile and confirm instruction files resolve in runtime.
+
+### 9) Capture evidence in PR
+Include run URLs and verification notes for:
+- Role repo creation
+- Sync workflow
+- Publish workflow
+- Container smoke check
+
+## Acceptance Criteria
+Use checkboxes. Keep these binary.
+
+- [ ] Role charter exists at `00-os/role-charters/<role-slug>.md`
+- [ ] Role instruction source exists at `10-templates/agent-instructions/roles/<role-slug>.md`
+- [ ] Role job spec exists at `10-templates/job-description-spec/roles/<role-slug>.json`
+- [ ] Role profile env exists at `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
+- [ ] Role is wired in both compose files
+- [ ] Role is wired in sync and publish workflow matrices
+- [ ] Public role repo exists at `<github-owner>/context-engineering-role-<role-slug>`
+- [ ] Sync workflow role job succeeded and produced/updated role-repo PR
+- [ ] Publish workflow role job succeeded for the new role
+- [ ] Only files listed in Scope were modified
+- [ ] No secrets, tokens, internal hostnames, IPs, or personal data introduced
+
+## PR Instructions
+- Open a PR titled: `Implementation Specialist: Add <role-slug> role end-to-end`
+- Include a summary mapped to Acceptance Criteria
+- Include machine-readable metadata:
+  - `Primary-Role: Implementation Specialist`
+  - `Reviewed-By-Role: Compliance Officer`
+  - `Executive-Sponsor-Approval: Required` if protected artifacts are touched, otherwise `Not-Required`
+- Link and close the Issue in the PR description (example: `Closes #<ISSUE_NUMBER>`)
+- Apply labels:
+  - `role:implementation-specialist`
+  - exactly one `status:*` label
+- Do not merge the PR
+
+### Branching (Required)
+Create a fresh branch for the Issue using GitHub CLI default naming.
+Manual `git checkout -b` is not allowed for Issue-driven work.
+
+Required commands (example):
+```bash
+gh issue develop <ISSUE_NUMBER> --checkout
+git branch --show-current
+```
+
+Stop Condition:
+- If not on a fresh Issue branch, stop and request human input.
+
+## Stop Conditions
+Stop execution immediately and request human input if:
+- The role slug/title conflicts with existing role artifacts
+- Required scope expansion is needed beyond this Issue
+- Workflow permissions/secrets prevent deterministic validation
+- Any instruction is ambiguous
+
+---
+
+## Context (Non-executable) (Optional)
+Add rationale, links, or discussion here. This section is non-executable and must not expand scope.


### PR DESCRIPTION
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Required

## Summary
- Added a canonical end-to-end role creation work-order template at `10-templates/agent-work-orders/role-creation-work-order.md`
- Added a GitHub issue launcher template at `.github/ISSUE_TEMPLATE/role-creation-request.md`
- Added discoverability links in `00-os/workflow.md`

## Acceptance Criteria Mapping
- [x] Canonical role creation work-order template added
- [x] Issue template added and mapped to work-order flow
- [x] Workflow index updated with role creation references
- [x] Scope-limited changes only
- [x] No secrets introduced

Closes #87

