### PR TITLE
Implementation Specialist: Add auto-merge for role-repo sync PRs

### DIFF
--- a/.github/workflows/sync-role-repos.yml
+++ b/.github/workflows/sync-role-repos.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: false
+      auto_merge:
+        description: Request GitHub auto-merge on sync PRs
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -130,12 +135,17 @@ jobs:
           SOURCE_REF_INPUT: ${{ github.event.inputs.source_ref }}
           DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
           NO_PR_INPUT: ${{ github.event.inputs.no_pr }}
+          AUTO_MERGE_INPUT: ${{ github.event.inputs.auto_merge }}
           GIT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           source_ref="$SOURCE_REF_INPUT"
           if [ -z "$source_ref" ]; then
             source_ref="$(printf '%s' "$GIT_SHA" | cut -c1-7)"
+          fi
+          auto_merge="$AUTO_MERGE_INPUT"
+          if [ -z "$auto_merge" ]; then
+            auto_merge="true"
           fi
 
           args=(
@@ -151,6 +161,10 @@ jobs:
 
           if [ "$NO_PR_INPUT" = "true" ]; then
             args+=(--no-pr)
+          fi
+
+          if [ "$auto_merge" = "true" ] && [ "$DRY_RUN_INPUT" != "true" ] && [ "$NO_PR_INPUT" != "true" ]; then
+            args+=(--auto-merge)
           fi
 
           10-templates/repo-starters/role-repo-template/scripts/sync-role-repo.sh "${args[@]}"

--- a/10-templates/repo-starters/role-repo-template/README.md
+++ b/10-templates/repo-starters/role-repo-template/README.md
@@ -141,6 +141,7 @@ Optional args:
 - `--sync-branch` (defaults to `sync/role-repo/<role-slug>`)
 - `--pr-title`
 - `--work-dir`
+- `--auto-merge` (best-effort request GitHub auto-merge on sync PR)
 - `--no-pr`
 - `--dry-run`
 
@@ -149,7 +150,8 @@ Example:
 ```bash
 10-templates/repo-starters/role-repo-template/scripts/sync-role-repo.sh \
   --role-slug implementation-specialist \
-  --owner Josh-Phillips-LLC
+  --owner Josh-Phillips-LLC \
+  --auto-merge
 ```
 
 Dry-run example:
@@ -175,6 +177,8 @@ Behavior:
   - `implementation-specialist`
   - `compliance-officer`
   - `systems-architect`
+- Requests auto-merge on generated sync PRs by default (unless `no_pr`/`dry_run` is used or manual `auto_merge` input is disabled).
+- Auto-merge request is best-effort and non-fatal; sync still succeeds if repo policy blocks auto-merge.
 
 Required secret:
 


### PR DESCRIPTION
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required

## Summary
- Added `--auto-merge` support to `sync-role-repo.sh` with best-effort, non-fatal behavior.
- Added sync workflow input/wiring so auto-merge is enabled by default for standard sync runs and can be disabled in manual dispatch.
- Updated role-repo template README to document auto-merge behavior and guardrails.

## Role-Repo Publication Gate Mapping
This change affects role-repo sync PR handling for all roles currently in the sync matrix:
- `implementation-specialist` -> `Josh-Phillips-LLC/context-engineering-role-implementation-specialist`
- `compliance-officer` -> `Josh-Phillips-LLC/context-engineering-role-compliance-officer`
- `systems-architect` -> `Josh-Phillips-LLC/context-engineering-role-systems-architect`

Operational impact:
- Sync PRs for the above role repos now request GitHub auto-merge by default.
- `dry_run` and `no_pr` flows remain non-merging.
- Auto-merge request is best-effort and non-fatal if repo policy/settings block it.

## Validation
- `bash -n 10-templates/repo-starters/role-repo-template/scripts/sync-role-repo.sh`
- `10-templates/repo-starters/role-repo-template/scripts/sync-role-repo.sh --help`
- `10-templates/repo-starters/role-repo-template/scripts/sync-role-repo.sh --role-slug systems-architect --owner Josh-Phillips-LLC --dry-run --auto-merge`

Closes #90
