### PR TITLE
Implementation Specialist: Add python3 to devcontainer Dockerfile

### DIFF
--- a/.devcontainer-workstation/Dockerfile
+++ b/.devcontainer-workstation/Dockerfile
@@ -9,7 +9,7 @@ RUN set -eux; \
       if apt-get ${APT_OPTIONS} update && \
          apt-get ${APT_OPTIONS} install -y --no-install-recommends \
            git curl ca-certificates openssh-client gnupg jq unzip \
-           poppler-utils mupdf-tools; then \
+           poppler-utils mupdf-tools python3; then \
         break; \
       fi; \
       if [ "${attempt}" -eq 5 ]; then \


### PR DESCRIPTION
## Summary
- Add python3 to the initial apt-get install block in .devcontainer-workstation/Dockerfile.
- Ensures role-repo rendering scripts (render-role-repo-template.sh) can run without manual python3 installation.

## Acceptance Criteria Mapping
- python3 is preinstalled in the devcontainer image by default.
- dockerfile modification is minimal and limited to python3 provisioning.
- No unrelated packages or configuration added.

## Issue
Closes #84

## Role Attribution (Required)
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required
