### PR TITLE
Implementation Specialist: App-per-role GitHub identity for role agents

### DIFF
--- a/.devcontainer-workstation/README.md
+++ b/.devcontainer-workstation/README.md
@@ -26,6 +26,15 @@ fi
 export GH_TOKEN="<your_pat>"
 export WORKSTATION_DEBUG="true" # optional: verbose init-workstation logging
 
+# Optional: role GitHub App auth (preferred for role-attributable actions)
+# ROLE_GITHUB_AUTH_MODE defaults to "app" in role profiles. If you are not
+# providing App credentials, set ROLE_GITHUB_AUTH_MODE="user" to skip.
+# The private key path must be mounted into the container (file path only).
+# export ROLE_GITHUB_AUTH_MODE="app"
+# export ROLE_GITHUB_APP_ID="<app-id>"
+# export ROLE_GITHUB_APP_INSTALLATION_ID="<installation-id>"
+# export ROLE_GITHUB_APP_PRIVATE_KEY_PATH="/run/secrets/role_github_app_private_key"
+
 # Default role-scoped startup (Implementation Specialist)
 $COMPOSE_CMD down
 $COMPOSE_CMD up -d --build implementation-workstation
@@ -90,6 +99,15 @@ If you exported `GH_TOKEN` for startup bootstrap, clear it after the container i
 ```bash
 unset GH_TOKEN
 ```
+
+If role GitHub App auth is configured, verify the role identity inside the container:
+
+```bash
+gh auth status --hostname github.com
+gh api /user --jq '.login'
+```
+
+If App auth variables are missing, startup logs a warning and continues without App auth.
 
 Use this only if you want a full reset of persisted container data:
 

--- a/.devcontainer-workstation/codex/role-profiles/README.md
+++ b/.devcontainer-workstation/codex/role-profiles/README.md
@@ -16,10 +16,19 @@ Each role profile is an `.env` file named `<role>.env` and may set:
 - `ROLE_WRITABLE_ROOTS` (JSON array string)
 - `ROLE_PROJECT_DOC_FALLBACK_FILENAMES` (JSON array string)
 
+Optional GitHub role auth values:
+
+- `ROLE_GITHUB_AUTH_MODE` (`app` or `user`, default `app`)
+- `ROLE_GITHUB_APP_ID`
+- `ROLE_GITHUB_APP_INSTALLATION_ID`
+- `ROLE_GITHUB_APP_PRIVATE_KEY_PATH` (path to a mounted private key file)
+
 Startup behavior:
 
 - Base config is seeded from `/etc/codex/config.toml` when `/root/.codex/config.toml` does not exist.
 - Role overlays then replace supported keys in `/root/.codex/config.toml`.
+- If `ROLE_GITHUB_AUTH_MODE=app` and all `ROLE_GITHUB_APP_*` values are set, startup runs the role GitHub App auth helper to mint a short-lived installation token and configure `gh`.
+- If any required `ROLE_GITHUB_APP_*` values are missing, startup prints a warning and continues without App auth.
 - `ROLE_PROFILE` defaults to image-baked `IMAGE_ROLE_PROFILE` when not explicitly set at runtime.
 - Runtime role instructions are generated at `/workspace/instructions/role-instructions.md` from role-repo `AGENTS.md` first, then image-baked compiled role instructions, then image-baked fallback sources.
 - Default runtime clone targets are role repos by role:

--- a/.devcontainer-workstation/codex/role-profiles/compliance-officer.env
+++ b/.devcontainer-workstation/codex/role-profiles/compliance-officer.env
@@ -4,3 +4,10 @@ ROLE_MODEL_REASONING_EFFORT="high"
 ROLE_MODEL_PERSONALITY="pragmatic"
 ROLE_WRITABLE_ROOTS='["/workspace/Projects"]'
 ROLE_PROJECT_DOC_FALLBACK_FILENAMES='["AGENTS.md", "copilot-instructions.md", ".role.instructions.md", "instructions.md"]'
+
+# GitHub role auth (app or user). Default is app.
+ROLE_GITHUB_AUTH_MODE="app"
+# GitHub App auth inputs (set when ROLE_GITHUB_AUTH_MODE=app).
+ROLE_GITHUB_APP_ID=""
+ROLE_GITHUB_APP_INSTALLATION_ID=""
+ROLE_GITHUB_APP_PRIVATE_KEY_PATH=""

--- a/.devcontainer-workstation/codex/role-profiles/implementation-specialist.env
+++ b/.devcontainer-workstation/codex/role-profiles/implementation-specialist.env
@@ -4,3 +4,10 @@ ROLE_MODEL_REASONING_EFFORT="xhigh"
 ROLE_MODEL_PERSONALITY="pragmatic"
 ROLE_WRITABLE_ROOTS='["/workspace/Projects"]'
 ROLE_PROJECT_DOC_FALLBACK_FILENAMES='["AGENTS.md", "copilot-instructions.md", ".role.instructions.md", "instructions.md"]'
+
+# GitHub role auth (app or user). Default is app.
+ROLE_GITHUB_AUTH_MODE="app"
+# GitHub App auth inputs (set when ROLE_GITHUB_AUTH_MODE=app).
+ROLE_GITHUB_APP_ID=""
+ROLE_GITHUB_APP_INSTALLATION_ID=""
+ROLE_GITHUB_APP_PRIVATE_KEY_PATH=""

--- a/.devcontainer-workstation/scripts/setup-role-github-app-auth.sh
+++ b/.devcontainer-workstation/scripts/setup-role-github-app-auth.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROLE_GITHUB_AUTH_MODE="${ROLE_GITHUB_AUTH_MODE:-}"
+ROLE_GITHUB_APP_ID="${ROLE_GITHUB_APP_ID:-}"
+ROLE_GITHUB_APP_INSTALLATION_ID="${ROLE_GITHUB_APP_INSTALLATION_ID:-}"
+ROLE_GITHUB_APP_PRIVATE_KEY_PATH="${ROLE_GITHUB_APP_PRIVATE_KEY_PATH:-}"
+
+if [ "$ROLE_GITHUB_AUTH_MODE" != "app" ]; then
+  echo "ROLE_GITHUB_AUTH_MODE is not set to app; skipping role GitHub App auth."
+  exit 0
+fi
+
+missing_vars=()
+if [ -z "$ROLE_GITHUB_APP_ID" ]; then
+  missing_vars+=("ROLE_GITHUB_APP_ID")
+fi
+if [ -z "$ROLE_GITHUB_APP_INSTALLATION_ID" ]; then
+  missing_vars+=("ROLE_GITHUB_APP_INSTALLATION_ID")
+fi
+if [ -z "$ROLE_GITHUB_APP_PRIVATE_KEY_PATH" ]; then
+  missing_vars+=("ROLE_GITHUB_APP_PRIVATE_KEY_PATH")
+fi
+
+if [ "${#missing_vars[@]}" -gt 0 ]; then
+  printf 'Missing required variables for role GitHub App auth: %s\n' "${missing_vars[*]}" >&2
+  exit 1
+fi
+
+if [ ! -r "$ROLE_GITHUB_APP_PRIVATE_KEY_PATH" ]; then
+  echo "GitHub App private key path is not readable: ${ROLE_GITHUB_APP_PRIVATE_KEY_PATH}" >&2
+  exit 1
+fi
+
+base64url() {
+  openssl base64 -e -A | tr '+/' '-_' | tr -d '='
+}
+
+now="$(date +%s)"
+iat="$((now - 30))"
+exp="$((now + 540))"
+header='{"alg":"RS256","typ":"JWT"}'
+payload="{\"iat\":${iat},\"exp\":${exp},\"iss\":\"${ROLE_GITHUB_APP_ID}\"}"
+
+header_b64="$(printf '%s' "$header" | base64url)"
+payload_b64="$(printf '%s' "$payload" | base64url)"
+unsigned_token="${header_b64}.${payload_b64}"
+signature="$(printf '%s' "$unsigned_token" | openssl dgst -sha256 -sign "$ROLE_GITHUB_APP_PRIVATE_KEY_PATH" | base64url)"
+app_jwt="${unsigned_token}.${signature}"
+
+installation_token="$(env -u GH_TOKEN -u GITHUB_TOKEN gh api \
+  --method POST \
+  -H "Authorization: Bearer ${app_jwt}" \
+  -H "Accept: application/vnd.github+json" \
+  "/app/installations/${ROLE_GITHUB_APP_INSTALLATION_ID}/access_tokens" \
+  --jq '.token' \
+)"
+
+if [ -z "$installation_token" ]; then
+  echo "Failed to mint GitHub App installation token." >&2
+  exit 1
+fi
+
+printf '%s' "$installation_token" | gh auth login --hostname github.com --git-protocol https --with-token >/dev/null
+
+gh auth setup-git >/dev/null
+
+principal="$(gh api /user --jq '.login' 2>/dev/null || true)"
+if [ -z "$principal" ]; then
+  principal="unknown"
+fi
+
+echo "GitHub App installation auth ready (principal: ${principal})."

--- a/.github/workflows/publish-role-workstation-images.yml
+++ b/.github/workflows/publish-role-workstation-images.yml
@@ -97,6 +97,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Authenticate to GHCR
+        # TODO(implementation-specialist): GHCR publish uses the repository automation identity
+        # (GITHUB_TOKEN) because GHCR write permissions are scoped to the workflow's repo
+        # and environment. Role GitHub App auth is not feasible here without separate
+        # app-granted package permissions and additional secret distribution.
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/sync-role-repos.yml
+++ b/.github/workflows/sync-role-repos.yml
@@ -63,13 +63,16 @@ jobs:
         include:
           - role_slug: implementation-specialist
             repo_name: context-engineering-role-implementation-specialist
+            app_id_secret: IMPLEMENTATION_SPECIALIST_APP_ID
+            private_key_secret: IMPLEMENTATION_SPECIALIST_APP_PRIVATE_KEY
           - role_slug: compliance-officer
             repo_name: context-engineering-role-compliance-officer
+            app_id_secret: COMPLIANCE_OFFICER_APP_ID
+            private_key_secret: COMPLIANCE_OFFICER_APP_PRIVATE_KEY
           - role_slug: systems-architect
             repo_name: context-engineering-role-systems-architect
-
-    env:
-      GH_TOKEN: ${{ secrets.ROLE_REPO_SYNC_TOKEN }}
+            app_id_secret: SYSTEMS_ARCHITECT_APP_ID
+            private_key_secret: SYSTEMS_ARCHITECT_APP_PRIVATE_KEY
 
     steps:
       - name: Evaluate matrix role selection
@@ -86,26 +89,6 @@ jobs:
             echo "run_sync=false" >> "$GITHUB_OUTPUT"
             echo "Skipping matrix role $MATRIX_ROLE for requested role $REQUESTED_ROLE"
           fi
-
-      - name: Validate sync token is configured
-        if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
-        run: |
-          set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "Missing secret ROLE_REPO_SYNC_TOKEN"
-            exit 1
-          fi
-
-      - name: Checkout repository
-        if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
-        uses: actions/checkout@v4
-
-      - name: Configure git auth for gh operations
-        if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
-        run: |
-          set -euo pipefail
-          gh auth status --hostname github.com
-          gh auth setup-git
 
       - name: Resolve target owner
         if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
@@ -129,9 +112,44 @@ jobs:
           fi
           echo "owner=$owner" >> "$GITHUB_OUTPUT"
 
+      - name: Create role GitHub App token
+        if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets[matrix.app_id_secret] }}
+          private-key: ${{ secrets[matrix.private_key_secret] }}
+          owner: ${{ steps.owner.outputs.owner }}
+          repositories: ${{ matrix.repo_name }}
+
+      - name: Validate sync token is configured
+        if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Missing role GitHub App token (check role app secrets)."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
+        uses: actions/checkout@v4
+
+      - name: Configure git auth for gh operations
+        if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh auth status --hostname github.com
+          gh auth setup-git
+
       - name: Sync role repository
         if: ${{ steps.role_filter.outputs.run_sync == 'true' }}
         env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           SOURCE_REF_INPUT: ${{ github.event.inputs.source_ref }}
           DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
           NO_PR_INPUT: ${{ github.event.inputs.no_pr }}

--- a/10-templates/repo-starters/role-repo-template/README.md
+++ b/10-templates/repo-starters/role-repo-template/README.md
@@ -182,15 +182,30 @@ Behavior:
 
 Required secret:
 
-- `ROLE_REPO_SYNC_TOKEN`
+- `IMPLEMENTATION_SPECIALIST_APP_ID`
+- `IMPLEMENTATION_SPECIALIST_APP_PRIVATE_KEY`
+- `COMPLIANCE_OFFICER_APP_ID`
+- `COMPLIANCE_OFFICER_APP_PRIVATE_KEY`
+- `SYSTEMS_ARCHITECT_APP_ID`
+- `SYSTEMS_ARCHITECT_APP_PRIVATE_KEY`
 
-`ROLE_REPO_SYNC_TOKEN` should be a token with access to target role repositories and permissions to push branches and open/edit pull requests.
+These secrets must map to GitHub Apps installed on the target role repositories. The sync workflow mints a short-lived installation token per role and uses it as `GH_TOKEN` for `gh` and git operations.
 
 Optional variable:
 
 - `ROLE_REPO_OWNER`
 
 If `ROLE_REPO_OWNER` is unset, workflow defaults to `github.repository_owner`.
+
+Verification (audit):
+
+- Check workflow logs for the `Configure git auth for gh operations` step and confirm `gh auth status` reports the expected role App identity.
+- Review the sync PR actor in the role repo; it should show the role App identity rather than a shared human account.
+
+Failure modes:
+
+- Missing role App secrets will stop the workflow with a missing token error.
+- If the App is not installed on a target role repo, token minting will fail.
 
 ## GitHub Actions GHCR Publish Path
 

--- a/10-templates/repo-starters/role-repo-template/scripts/sync-role-repo.sh
+++ b/10-templates/repo-starters/role-repo-template/scripts/sync-role-repo.sh
@@ -141,6 +141,10 @@ for cmd in gh git python3; do
   fi
 done
 
+if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+  export GH_TOKEN="$GITHUB_TOKEN"
+fi
+
 if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
   if ! gh auth status --hostname github.com >/dev/null 2>&1; then
     echo "GitHub CLI not authenticated. Run: gh auth login" >&2


### PR DESCRIPTION
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required

## Summary
- Adds role GitHub App auth contract to role profiles and workstation init helper to mint short-lived installation tokens (AC: workstation supports app auth; non-fatal missing vars).
- Updates sync workflow to use per-role GitHub App tokens and keeps sync script token-source agnostic (AC: sync role repos use role app identity; sync script works in CI/local).
- Documents role App setup, verification, and failure modes; adds GHCR publish TODO rationale (AC: docs define setup/verification/failure modes).

## Acceptance Criteria Mapping
- Scoped changes only to allowed files; no secrets committed.
- ROLE_GITHUB_AUTH_MODE=app uses helper script for `gh` auth; missing vars warn and continue.
- Sync workflow uses role App credentials per matrix entry and sets `GH_TOKEN`.
- Docs include setup, verification, and failure-mode guidance.

## Affected Roles
- implementation-specialist
- compliance-officer
- systems-architect
- future roles added to the sync matrix

## Deterministic Validation Evidence
- Compliance Officer role App auth verified: https://github.com/Josh-Phillips-LLC/Context-Engineering/actions/runs/21963488608
- Implementation Specialist role App auth verified: https://github.com/Josh-Phillips-LLC/Context-Engineering/actions/runs/21963553031
- Systems Architect role App auth verified: https://github.com/Josh-Phillips-LLC/Context-Engineering/actions/runs/21963594296

Closes #78
