### PR TITLE
Implementation Specialist: Prevent GH token env override of role App identity in workstation

### DIFF
--- a/.devcontainer-workstation/README.md
+++ b/.devcontainer-workstation/README.md
@@ -20,15 +20,16 @@ else
   COMPOSE_CMD="docker-compose"
 fi
 
-# Optional: set this before startup when the workspace repo is private
-# or you want non-interactive auth/auto-clone on first boot.
-
-export GH_TOKEN="<your_pat>"
+# Optional: set this before startup when ROLE_GITHUB_AUTH_MODE=user and
+# the workspace repo is private or you want non-interactive first-boot auth.
+export GH_BOOTSTRAP_TOKEN="<your_pat>"
 export WORKSTATION_DEBUG="true" # optional: verbose init-workstation logging
 
 # Optional: role GitHub App auth (preferred for role-attributable actions)
 # ROLE_GITHUB_AUTH_MODE defaults to "app" in role profiles. If you are not
 # providing App credentials, set ROLE_GITHUB_AUTH_MODE="user" to skip.
+# Keep GH_TOKEN/GITHUB_TOKEN unset in app mode; those env vars override
+# role-app identity for gh/MCP calls when present in container env.
 # The private key path must be mounted into the container (file path only).
 # export ROLE_GITHUB_AUTH_MODE="app"
 # export ROLE_GITHUB_APP_ID="<app-id>"
@@ -94,10 +95,10 @@ docker buildx imagetools inspect ghcr.io/josh-phillips-llc/context-engineering-w
 docker buildx imagetools inspect ghcr.io/josh-phillips-llc/context-engineering-workstation-systems-architect:latest
 ```
 
-If you exported `GH_TOKEN` for startup bootstrap, clear it after the container is running:
+If you exported `GH_BOOTSTRAP_TOKEN` for startup bootstrap, clear it after the container is running:
 
 ```bash
-unset GH_TOKEN
+unset GH_BOOTSTRAP_TOKEN
 ```
 
 If role GitHub App auth is configured, verify the role identity inside the container:
@@ -167,7 +168,7 @@ docker exec -it implementation-workstation bash
 
 # One-time fallback auth inside container (HTTPS + PAT)
 read -s -p "GitHub PAT: " GH_PAT; echo
-printf '%s' "$GH_PAT" | env -u GH_TOKEN gh auth login --hostname github.com --git-protocol https --with-token
+printf '%s' "$GH_PAT" | env -u GH_TOKEN -u GITHUB_TOKEN gh auth login --hostname github.com --git-protocol https --with-token
 gh auth setup-git
 gh auth status
 unset GH_PAT

--- a/.devcontainer-workstation/codex/config.toml
+++ b/.devcontainer-workstation/codex/config.toml
@@ -22,7 +22,7 @@ web_search = "live"
 inherit = "core"
 ignore_default_excludes = false
 exclude = ["AWS_*", "AZURE_*", "*_SESSION_*"]
-include_only = ["PATH", "HOME", "LANG", "LC_*", "TERM", "TMPDIR", "CODEX_HOME", "OPENAI_API_KEY", "GH_TOKEN"]
+include_only = ["PATH", "HOME", "LANG", "LC_*", "TERM", "TMPDIR", "CODEX_HOME", "OPENAI_API_KEY"]
 set = { GIT_TERMINAL_PROMPT = "0" }
 experimental_use_profile = false
 

--- a/.devcontainer-workstation/docker-compose.ghcr.yml
+++ b/.devcontainer-workstation/docker-compose.ghcr.yml
@@ -9,11 +9,15 @@ services:
       - implementation_git_config:/root/.config/git
       - implementation_codex_home:/root/.codex
     environment:
-      - GH_TOKEN=${GH_TOKEN:-}
+      - GH_BOOTSTRAP_TOKEN=${GH_BOOTSTRAP_TOKEN:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - WORKSTATION_DEBUG=${WORKSTATION_DEBUG:-false}
       - CODEX_HOME=/root/.codex
       - ROLE_PROFILE=${ROLE_PROFILE:-implementation-specialist}
+      - ROLE_GITHUB_AUTH_MODE=${ROLE_GITHUB_AUTH_MODE:-}
+      - ROLE_GITHUB_APP_ID=${ROLE_GITHUB_APP_ID:-}
+      - ROLE_GITHUB_APP_INSTALLATION_ID=${ROLE_GITHUB_APP_INSTALLATION_ID:-}
+      - ROLE_GITHUB_APP_PRIVATE_KEY_PATH=${ROLE_GITHUB_APP_PRIVATE_KEY_PATH:-}
       - WORKSPACE_REPO_OWNER=${WORKSPACE_REPO_OWNER:-Josh-Phillips-LLC}
       - WORKSPACE_REPO_URL=${IMPLEMENTATION_WORKSPACE_REPO_URL:-https://github.com/Josh-Phillips-LLC/context-engineering-role-implementation-specialist.git}
       - WORKSPACE_REPO_DIR=/workspace/Projects/${IMPLEMENTATION_WORKSPACE_REPO_DIR_NAME:-context-engineering-role-implementation-specialist}
@@ -38,11 +42,15 @@ services:
       - compliance_git_config:/root/.config/git
       - compliance_codex_home:/root/.codex
     environment:
-      - GH_TOKEN=${GH_TOKEN:-}
+      - GH_BOOTSTRAP_TOKEN=${GH_BOOTSTRAP_TOKEN:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - WORKSTATION_DEBUG=${WORKSTATION_DEBUG:-false}
       - CODEX_HOME=/root/.codex
       - ROLE_PROFILE=compliance-officer
+      - ROLE_GITHUB_AUTH_MODE=${ROLE_GITHUB_AUTH_MODE:-}
+      - ROLE_GITHUB_APP_ID=${ROLE_GITHUB_APP_ID:-}
+      - ROLE_GITHUB_APP_INSTALLATION_ID=${ROLE_GITHUB_APP_INSTALLATION_ID:-}
+      - ROLE_GITHUB_APP_PRIVATE_KEY_PATH=${ROLE_GITHUB_APP_PRIVATE_KEY_PATH:-}
       - WORKSPACE_REPO_OWNER=${WORKSPACE_REPO_OWNER:-Josh-Phillips-LLC}
       - WORKSPACE_REPO_URL=${COMPLIANCE_WORKSPACE_REPO_URL:-https://github.com/Josh-Phillips-LLC/context-engineering-role-compliance-officer.git}
       - WORKSPACE_REPO_DIR=/workspace/Projects/${COMPLIANCE_WORKSPACE_REPO_DIR_NAME:-context-engineering-role-compliance-officer}
@@ -67,11 +75,15 @@ services:
       - systems_architect_git_config:/root/.config/git
       - systems_architect_codex_home:/root/.codex
     environment:
-      - GH_TOKEN=${GH_TOKEN:-}
+      - GH_BOOTSTRAP_TOKEN=${GH_BOOTSTRAP_TOKEN:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - WORKSTATION_DEBUG=${WORKSTATION_DEBUG:-false}
       - CODEX_HOME=/root/.codex
       - ROLE_PROFILE=systems-architect
+      - ROLE_GITHUB_AUTH_MODE=${ROLE_GITHUB_AUTH_MODE:-}
+      - ROLE_GITHUB_APP_ID=${ROLE_GITHUB_APP_ID:-}
+      - ROLE_GITHUB_APP_INSTALLATION_ID=${ROLE_GITHUB_APP_INSTALLATION_ID:-}
+      - ROLE_GITHUB_APP_PRIVATE_KEY_PATH=${ROLE_GITHUB_APP_PRIVATE_KEY_PATH:-}
       - WORKSPACE_REPO_OWNER=${WORKSPACE_REPO_OWNER:-Josh-Phillips-LLC}
       - WORKSPACE_REPO_URL=${SYSTEMS_ARCHITECT_WORKSPACE_REPO_URL:-https://github.com/Josh-Phillips-LLC/context-engineering-role-systems-architect.git}
       - WORKSPACE_REPO_DIR=/workspace/Projects/${SYSTEMS_ARCHITECT_WORKSPACE_REPO_DIR_NAME:-context-engineering-role-systems-architect}

--- a/.devcontainer-workstation/docker-compose.yml
+++ b/.devcontainer-workstation/docker-compose.yml
@@ -18,12 +18,16 @@ services:
       #  source: ${HOST_SSH_AGENT_SOCK:-/tmp/codex-no-ssh-agent}
       #  target: /ssh-agent
     environment:
-      - GH_TOKEN=${GH_TOKEN:-}
+      - GH_BOOTSTRAP_TOKEN=${GH_BOOTSTRAP_TOKEN:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - WORKSTATION_DEBUG=${WORKSTATION_DEBUG:-false}
       - CODEX_HOME=/root/.codex
       # - SSH_AUTH_SOCK=/ssh-agent
       - ROLE_PROFILE=${ROLE_PROFILE:-implementation-specialist}
+      - ROLE_GITHUB_AUTH_MODE=${ROLE_GITHUB_AUTH_MODE:-}
+      - ROLE_GITHUB_APP_ID=${ROLE_GITHUB_APP_ID:-}
+      - ROLE_GITHUB_APP_INSTALLATION_ID=${ROLE_GITHUB_APP_INSTALLATION_ID:-}
+      - ROLE_GITHUB_APP_PRIVATE_KEY_PATH=${ROLE_GITHUB_APP_PRIVATE_KEY_PATH:-}
       - WORKSPACE_REPO_OWNER=${WORKSPACE_REPO_OWNER:-Josh-Phillips-LLC}
       - WORKSPACE_REPO_URL=${IMPLEMENTATION_WORKSPACE_REPO_URL:-https://github.com/Josh-Phillips-LLC/context-engineering-role-implementation-specialist.git}
       - WORKSPACE_REPO_DIR=/workspace/Projects/${IMPLEMENTATION_WORKSPACE_REPO_DIR_NAME:-context-engineering-role-implementation-specialist}
@@ -58,12 +62,16 @@ services:
       #  source: ${HOST_SSH_AGENT_SOCK:-/tmp/codex-no-ssh-agent}
       #  target: /ssh-agent
     environment:
-      - GH_TOKEN=${GH_TOKEN:-}
+      - GH_BOOTSTRAP_TOKEN=${GH_BOOTSTRAP_TOKEN:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - WORKSTATION_DEBUG=${WORKSTATION_DEBUG:-false}
       - CODEX_HOME=/root/.codex
       # - SSH_AUTH_SOCK=/ssh-agent
       - ROLE_PROFILE=compliance-officer
+      - ROLE_GITHUB_AUTH_MODE=${ROLE_GITHUB_AUTH_MODE:-}
+      - ROLE_GITHUB_APP_ID=${ROLE_GITHUB_APP_ID:-}
+      - ROLE_GITHUB_APP_INSTALLATION_ID=${ROLE_GITHUB_APP_INSTALLATION_ID:-}
+      - ROLE_GITHUB_APP_PRIVATE_KEY_PATH=${ROLE_GITHUB_APP_PRIVATE_KEY_PATH:-}
       - WORKSPACE_REPO_OWNER=${WORKSPACE_REPO_OWNER:-Josh-Phillips-LLC}
       - WORKSPACE_REPO_URL=${COMPLIANCE_WORKSPACE_REPO_URL:-https://github.com/Josh-Phillips-LLC/context-engineering-role-compliance-officer.git}
       - WORKSPACE_REPO_DIR=/workspace/Projects/${COMPLIANCE_WORKSPACE_REPO_DIR_NAME:-context-engineering-role-compliance-officer}
@@ -98,12 +106,16 @@ services:
       #  source: ${HOST_SSH_AGENT_SOCK:-/tmp/codex-no-ssh-agent}
       #  target: /ssh-agent
     environment:
-      - GH_TOKEN=${GH_TOKEN:-}
+      - GH_BOOTSTRAP_TOKEN=${GH_BOOTSTRAP_TOKEN:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - WORKSTATION_DEBUG=${WORKSTATION_DEBUG:-false}
       - CODEX_HOME=/root/.codex
       # - SSH_AUTH_SOCK=/ssh-agent
       - ROLE_PROFILE=systems-architect
+      - ROLE_GITHUB_AUTH_MODE=${ROLE_GITHUB_AUTH_MODE:-}
+      - ROLE_GITHUB_APP_ID=${ROLE_GITHUB_APP_ID:-}
+      - ROLE_GITHUB_APP_INSTALLATION_ID=${ROLE_GITHUB_APP_INSTALLATION_ID:-}
+      - ROLE_GITHUB_APP_PRIVATE_KEY_PATH=${ROLE_GITHUB_APP_PRIVATE_KEY_PATH:-}
       - WORKSPACE_REPO_OWNER=${WORKSPACE_REPO_OWNER:-Josh-Phillips-LLC}
       - WORKSPACE_REPO_URL=${SYSTEMS_ARCHITECT_WORKSPACE_REPO_URL:-https://github.com/Josh-Phillips-LLC/context-engineering-role-systems-architect.git}
       - WORKSPACE_REPO_DIR=/workspace/Projects/${SYSTEMS_ARCHITECT_WORKSPACE_REPO_DIR_NAME:-context-engineering-role-systems-architect}


### PR DESCRIPTION
Primary-Role: Implementation Specialist
Reviewed-By-Role: N/A
Executive-Sponsor-Approval: Not-Required

## Summary
- Replaced long-lived container `GH_TOKEN` injection with `GH_BOOTSTRAP_TOKEN` in both local-build and GHCR compose files to avoid runtime identity override.
- Passed through `ROLE_GITHUB_AUTH_MODE` and `ROLE_GITHUB_APP_*` env vars in compose so role App auth can be configured deterministically at startup.
- Updated startup bootstrap logic to use `GH_BOOTSTRAP_TOKEN`, and to explicitly ignore bootstrap PAT auth when `ROLE_GITHUB_AUTH_MODE=app`.
- Updated workstation docs and fallback manual auth command to reflect the new bootstrap variable and App-mode precedence rules.
- Removed `GH_TOKEN` from default Codex shell environment passthrough to reduce accidental ambient-token override risk.

## Validation
- `bash -n .devcontainer-workstation/scripts/init-workstation.sh`
- `docker compose -f .devcontainer-workstation/docker-compose.yml config`
- `docker compose -f .devcontainer-workstation/docker-compose.ghcr.yml config`
- Live container diagnosis (before fix rollout) confirmed the root cause:
  - `GH_TOKEN_PRESENT=yes`
  - `viewer_with_env=joshphillipssr`
  - startup warning showed App auth skipped when `ROLE_GITHUB_APP_*` values were absent

Closes #97
