### PR TITLE
Implementation Specialist: role workstation gh auth self-heal contract + wrapper

### DIFF
--- a/.devcontainer-workstation/Dockerfile
+++ b/.devcontainer-workstation/Dockerfile
@@ -101,7 +101,8 @@ RUN set -eux; \
 COPY .devcontainer-workstation/scripts/init-workstation.sh /usr/local/bin/init-workstation.sh
 COPY .devcontainer-workstation/scripts/setup-role-github-app-auth.sh /usr/local/bin/setup-role-github-app-auth.sh
 COPY .devcontainer-workstation/scripts/remint-role-github-app-auth.sh /usr/local/bin/remint-role-github-app-auth.sh
-RUN chmod +x /usr/local/bin/init-workstation.sh /usr/local/bin/setup-role-github-app-auth.sh /usr/local/bin/remint-role-github-app-auth.sh
+COPY .devcontainer-workstation/scripts/gh-role.sh /usr/local/bin/gh-role
+RUN chmod +x /usr/local/bin/init-workstation.sh /usr/local/bin/setup-role-github-app-auth.sh /usr/local/bin/remint-role-github-app-auth.sh /usr/local/bin/gh-role
 ENV IMAGE_ROLE_PROFILE=${IMAGE_ROLE_PROFILE}
 
 WORKDIR /workspace

--- a/.devcontainer-workstation/README.md
+++ b/.devcontainer-workstation/README.md
@@ -160,6 +160,15 @@ When `gh` starts failing later with `401 Bad credentials` (expired installation 
 gh auth status --hostname github.com
 ```
 
+For self-healing CLI usage, prefer the role-safe wrapper:
+
+```bash
+gh-role issue list
+gh-role pr list
+```
+
+`gh-role` runs `gh` with `GH_TOKEN`/`GITHUB_TOKEN` unset and auto-runs `/usr/local/bin/remint-role-github-app-auth.sh` in app mode when auth is stale.
+
 The helper resolves role app metadata from runtime startup output at `/workspace/instructions/role-github-app-auth.env`.
 It defaults the key path to `/run/secrets/role_github_app_private_key` when not explicitly set.
 

--- a/.devcontainer-workstation/scripts/gh-role.sh
+++ b/.devcontainer-workstation/scripts/gh-role.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMINT_HELPER="${REMINT_HELPER:-/usr/local/bin/remint-role-github-app-auth.sh}"
+MODE="${ROLE_GITHUB_AUTH_MODE:-${RUNTIME_ROLE_GITHUB_AUTH_MODE:-}}"
+
+auth_ok() {
+  env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --hostname github.com >/dev/null 2>&1
+}
+
+if ! auth_ok && [ "$MODE" = "app" ] && [ -x "$REMINT_HELPER" ]; then
+  "$REMINT_HELPER" >/dev/null
+fi
+
+exec env -u GH_TOKEN -u GITHUB_TOKEN gh "$@"

--- a/10-templates/agent-instructions/base.md
+++ b/10-templates/agent-instructions/base.md
@@ -26,3 +26,26 @@ If an instruction conflicts with authoritative policy, escalate rather than gues
 - Ambiguous authority boundaries
 - Scope expansion beyond the issue definition
 - Any uncertainty around safety or publication boundaries
+
+## GitHub Auth Self-Heal (Role Workstations)
+
+If you are running inside a role workstation container:
+
+- Treat role-app auth as authoritative when `ROLE_GITHUB_AUTH_MODE=app`.
+- Do not run `gh auth login` in app mode.
+- Always run GitHub CLI with `GH_TOKEN` and `GITHUB_TOKEN` unset so persisted role auth is used.
+- If `gh` auth fails, re-mint role app auth before retrying:
+  - `/usr/local/bin/remint-role-github-app-auth.sh`
+- Prefer wrapper usage when available:
+  - `gh-role <gh-args>`
+
+Verification commands:
+
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --hostname github.com`
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh api /user --jq '.login'`
+
+Only escalate after re-mint fails. Include:
+
+- `gh auth status --hostname github.com`
+- `ls -l /run/secrets/role_github_app_private_key`
+- `cat /workspace/instructions/role-github-app-auth.env`


### PR DESCRIPTION
## Summary
Implements deterministic GitHub auth self-heal behavior for role workstations so agents stop asking for manual re-auth when app auth is stale.

## Changes
- Updated `10-templates/agent-instructions/base.md` with explicit app-mode auth contract:
  - do not run `gh auth login` in app mode
  - run `gh` with `GH_TOKEN/GITHUB_TOKEN` unset
  - re-mint with `/usr/local/bin/remint-role-github-app-auth.sh` on failure
- Added `.devcontainer-workstation/scripts/gh-role.sh` wrapper:
  - checks `gh` auth in role-safe env
  - auto-runs deterministic re-mint in app mode when stale
  - executes `gh` with `GH_TOKEN/GITHUB_TOKEN` unset
- Updated `.devcontainer-workstation/Dockerfile` to install `/usr/local/bin/gh-role`
- Updated `.devcontainer-workstation/README.md` with `gh-role` usage guidance

## Validation
- `bash -n .devcontainer-workstation/scripts/gh-role.sh`
- `bash -n .devcontainer-workstation/scripts/remint-role-github-app-auth.sh`
- `bash -n .devcontainer-workstation/scripts/setup-role-github-app-auth.sh`

## Acceptance Criteria
- [x] Canonical instructions define self-heal sequence
- [x] Workstation image includes `/usr/local/bin/gh-role`
- [x] `gh-role` unsets env token overrides and remints in app mode when stale
- [x] README documents usage and behavior

Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required

Closes #135