### PR TITLE
Implementation Specialist: align role-onboarding templates and app bootstrap validator with registry-first workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/role-creation-request.md
+++ b/.github/ISSUE_TEMPLATE/role-creation-request.md
@@ -10,8 +10,10 @@ labels: ["change-request"]
 ## Required Inputs
 - Role title:
 - Role slug (kebab-case):
+- Role menu label/shorthand:
 - Role repo owner (organization/user):
 - Role repo name override (optional, default `context-engineering-role-<role-slug>`):
+- Role env prefix (uppercase snake case):
 
 ## Scope (Allowed Changes)
 - In scope:
@@ -22,12 +24,12 @@ labels: ["change-request"]
 - [ ] Create role instruction source at `10-templates/agent-instructions/roles/<role-slug>.md`
 - [ ] Create role job-description spec at `10-templates/job-description-spec/roles/<role-slug>.json`
 - [ ] Add role profile env at `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
-- [ ] Wire role in `.devcontainer-workstation/docker-compose.yml`
-- [ ] Wire role in `.devcontainer-workstation/docker-compose.ghcr.yml`
-- [ ] Update launcher touchpoints in `.devcontainer-workstation/scripts/start-role-workstation.sh`
-- [ ] Update launcher guidance in `.devcontainer-workstation/README.md` if role lists/examples are present
-- [ ] Add role to `.github/workflows/sync-role-repos.yml` matrix
-- [ ] Add role to `.github/workflows/publish-role-workstation-images.yml` matrix
+- [ ] Add role entry to `00-os/role-registry.yml` with GitHub App + compose + menu metadata
+- [ ] Run `python3 00-os/scripts/generate-role-wiring.py` to generate role wiring
+- [ ] Confirm generated wiring updates are present in compose/workflow/launcher generated sections
+- [ ] Run `python3 00-os/scripts/generate-role-wiring.py --check`
+- [ ] Run onboarding validator: `10-templates/repo-starters/role-repo-template/scripts/validate-role-onboarding.sh --role-slug <role-slug>`
+- [ ] Run app bootstrap validator: `00-os/scripts/validate-github-app-setup.sh --role-slug <role-slug> --org <owner>`
 - [ ] Create public role repo scaffold via `create-public-role-repo.sh`
 - [ ] Verify sync workflow success for the new role
 - [ ] Verify publish workflow success for the new role

--- a/00-os/runbooks/github-app-bootstrap-validation.md
+++ b/00-os/runbooks/github-app-bootstrap-validation.md
@@ -28,8 +28,11 @@ GitHub Apps require manual creation and installation by org admins. This validat
 # Validate a specific role
 ./00-os/scripts/validate-github-app-setup.sh --role-slug implementation-specialist
 
+# Validate a newly added role
+./00-os/scripts/validate-github-app-setup.sh --role-slug hr-and-ai-agent
+
 # Validate for different org
-./00-os/scripts/validate-github-app-setup.sh --role-slug compliance-officer --org MyOrg
+./00-os/scripts/validate-github-app-setup.sh --role-slug systems-architect --org MyOrg
 
 # Help
 ./00-os/scripts/validate-github-app-setup.sh --help
@@ -38,8 +41,8 @@ GitHub Apps require manual creation and installation by org admins. This validat
 ### What It Checks
 
 1. **Organization Secrets**
-   - `{ROLE}_APP_ID` exists
-   - `{ROLE}_APP_PRIVATE_KEY` exists
+   - `{ROLE_SLUG_UPPER_SNAKE}_APP_ID` exists
+   - `{ROLE_SLUG_UPPER_SNAKE}_APP_PRIVATE_KEY` exists
 
 2. **App Installation**
    - App slug follows naming convention
@@ -62,7 +65,7 @@ GitHub Apps require manual creation and installation by org admins. This validat
 ## Naming Conventions
 
 ### App Slug
-Current pattern in this org: `a-{role-slug-without-hyphens}`  
+Current pattern in this org: `a-{role-slug-without-non-alphanumeric-characters}`  
 Legacy/alternate pattern accepted by validator: `context-engineering-{role-slug}`
 
 Examples:
@@ -75,21 +78,19 @@ Examples:
 
 ### Organization Secrets
 
-**App ID Secret**:
-Pattern: `{ROLE_UPPERCASE}_APP_ID`
+The validator derives secret names directly from `--role-slug`:
+
+- Convert slug to uppercase snake case (`[^A-Z0-9]` becomes `_`)
+- Append `_APP_ID` and `_APP_PRIVATE_KEY`
+
+Pattern:
+- App ID: `{ROLE_SLUG_UPPER_SNAKE}_APP_ID`
+- Private key: `{ROLE_SLUG_UPPER_SNAKE}_APP_PRIVATE_KEY`
 
 Examples:
-- `IMPLEMENTATION_SPECIALIST_APP_ID`
-- `COMPLIANCE_OFFICER_APP_ID`
-- `SYSTEMS_ARCHITECT_APP_ID`
-
-**Private Key Secret**:
-Pattern: `{ROLE_UPPERCASE}_APP_PRIVATE_KEY`
-
-Examples:
-- `IMPLEMENTATION_SPECIALIST_APP_PRIVATE_KEY`
-- `COMPLIANCE_OFFICER_APP_PRIVATE_KEY`
-- `SYSTEMS_ARCHITECT_APP_PRIVATE_KEY`
+- `implementation-specialist` -> `IMPLEMENTATION_SPECIALIST_APP_ID`
+- `compliance-officer` -> `COMPLIANCE_OFFICER_APP_PRIVATE_KEY`
+- `hr-and-ai-agent` -> `HR_AND_AI_AGENT_APP_ID`
 
 ### Installation ID Source
 Installation IDs are validated from GitHub's installation API, not org secrets:
@@ -108,7 +109,8 @@ When validation reports missing configuration:
 
 1. Navigate to: `https://github.com/organizations/{ORG}/settings/apps/new`
 2. Configure:
-   - **Name**: `context-engineering-{role-slug}`
+   - **Name (preferred)**: `a-{role-slug-without-non-alphanumeric-characters}`
+   - **Name (legacy accepted by validator)**: `context-engineering-{role-slug}`
    - **Homepage URL**: `https://github.com/{ORG}/Context-Engineering`
    - **Webhook**: Inactive (not needed for role agents)
    - **Permissions**: Per role charter requirements
@@ -129,12 +131,12 @@ When validation reports missing configuration:
 
 ```bash
 # Set App ID
-gh secret set {ROLE_UPPERCASE}_APP_ID \
+gh secret set {ROLE_SLUG_UPPER_SNAKE}_APP_ID \
   --org {ORG} \
   --body "{app_id}"
 
 # Set Private Key  
-gh secret set {ROLE_UPPERCASE}_APP_PRIVATE_KEY \
+gh secret set {ROLE_SLUG_UPPER_SNAKE}_APP_PRIVATE_KEY \
   --org {ORG} \
   < path/to/{role-slug}.private-key.pem
 ```

--- a/00-os/scripts/validate-github-app-setup.sh
+++ b/00-os/scripts/validate-github-app-setup.sh
@@ -62,33 +62,36 @@ echo "=== GitHub App Setup Validation for ${ROLE_SLUG} ==="
 echo "Organization: ${ORG}"
 echo ""
 
-# Determine expected secret names based on role slug
-case "$ROLE_SLUG" in
-  implementation-specialist)
-    APP_ID_SECRET="IMPLEMENTATION_SPECIALIST_APP_ID"
-    PRIVATE_KEY_SECRET="IMPLEMENTATION_SPECIALIST_APP_PRIVATE_KEY"
-    ;;
-  compliance-officer)
-    APP_ID_SECRET="COMPLIANCE_OFFICER_APP_ID"
-    PRIVATE_KEY_SECRET="COMPLIANCE_OFFICER_APP_PRIVATE_KEY"
-    ;;
-  systems-architect)
-    APP_ID_SECRET="SYSTEMS_ARCHITECT_APP_ID"
-    PRIVATE_KEY_SECRET="SYSTEMS_ARCHITECT_APP_PRIVATE_KEY"
-    ;;
-  *)
-    echo "⚠️  Unknown role slug: ${ROLE_SLUG}" >&2
-    echo "    Cannot determine expected naming conventions." >&2
-    echo "    Please add this role to the script or verify manually." >&2
-    exit 1
-    ;;
-esac
+# Determine expected secret names based on role slug naming convention.
+# Convention:
+#   <role-slug> -> <ROLE_SLUG_UPPER_SNAKE>_APP_ID / _APP_PRIVATE_KEY
+role_secret_prefix="$(
+  printf '%s' "$ROLE_SLUG" \
+    | tr '[:lower:]' '[:upper:]' \
+    | sed -E 's/[^A-Z0-9]+/_/g; s/^_+//; s/_+$//; s/_+/_/g'
+)"
+
+if [ -z "$role_secret_prefix" ]; then
+  echo "❌ Could not derive secret naming prefix from role slug: ${ROLE_SLUG}" >&2
+  exit 1
+fi
+
+APP_ID_SECRET="${role_secret_prefix}_APP_ID"
+PRIVATE_KEY_SECRET="${role_secret_prefix}_APP_PRIVATE_KEY"
 
 validation_errors=0
 validation_warnings=0
 context_repo="Context-Engineering"
 role_repo="context-engineering-role-${ROLE_SLUG}"
-role_slug_compact="${ROLE_SLUG//-/}"
+role_slug_compact="$(
+  printf '%s' "$ROLE_SLUG" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -cd '[:alnum:]'
+)"
+if [ -z "$role_slug_compact" ]; then
+  echo "❌ Could not derive app slug naming from role slug: ${ROLE_SLUG}" >&2
+  exit 1
+fi
 EXPECTED_APP_SLUG_PRIMARY="a-${role_slug_compact}"
 EXPECTED_APP_SLUG_LEGACY="context-engineering-${ROLE_SLUG}"
 

--- a/10-templates/agent-work-orders/role-creation-work-order.md
+++ b/10-templates/agent-work-orders/role-creation-work-order.md
@@ -16,16 +16,18 @@ List the **only** files/folders the Implementation Specialist may modify for thi
 
 - The Implementation Specialist may ONLY modify:
   - `00-os/role-charters/<role-slug>.md`
+  - `00-os/role-registry.yml`
   - `10-templates/agent-instructions/roles/<role-slug>.md`
   - `10-templates/job-description-spec/roles/<role-slug>.json`
   - `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
-  - `.devcontainer-workstation/docker-compose.yml`
-  - `.devcontainer-workstation/docker-compose.ghcr.yml`
-  - `.devcontainer-workstation/scripts/start-role-workstation.sh`
-  - `.devcontainer-workstation/README.md`
-  - `.github/workflows/sync-role-repos.yml`
-  - `.github/workflows/publish-role-workstation-images.yml`
+  - Generated outputs from `00-os/scripts/generate-role-wiring.py`:
+    - `.devcontainer-workstation/docker-compose.yml` (generated sections only)
+    - `.devcontainer-workstation/docker-compose.ghcr.yml` (generated sections only)
+    - `.devcontainer-workstation/scripts/start-role-workstation.sh` (generated sections only)
+    - `.github/workflows/sync-role-repos.yml` (generated sections only)
+    - `.github/workflows/publish-role-workstation-images.yml` (generated sections only)
   - `10-templates/repo-starters/role-repo-template/**` (only if template source changes are explicitly required)
+  - `.devcontainer-workstation/README.md` (only if role lists/examples require update)
   - Any additional files explicitly listed below for this role
 
 State whether new files may be created (default: **Yes**, only those implied by the listed paths and role slug).
@@ -39,7 +41,7 @@ List explicit exclusions so scope does not expand.
 - Protected artifacts unless explicitly included:
   - `governance.md`
   - `context-flow.md`
-  - `00-os/**` files other than the role charter in Scope
+- Manual edits inside generated marker blocks without running the role wiring generator
 - Unrelated refactors or formatting-only edits
 - Runtime behavior changes unrelated to adding the new role
 - Merging PRs
@@ -51,10 +53,13 @@ Fill in all placeholders before execution.
 
 - Role title: `<Role Title>`
 - Role slug (kebab-case): `<role-slug>`
+- Role shorthand/menu label: `<role-menu-label>`
 - Role repo owner: `<github-owner>`
 - Role repo name (default): `context-engineering-role-<role-slug>`
-- Role workstation service name: `<role-slug>-workstation`
-- Role profile env file: `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
+- Role workstation service name (default): `<role-slug>-workstation`
+- Role env prefix (uppercase snake case): `<ROLE_ENV_PREFIX>`
+- Role app ID secret name: `<ROLE_ENV_PREFIX>_APP_ID`
+- Role app private key secret name: `<ROLE_ENV_PREFIX>_APP_PRIVATE_KEY`
 
 ## Implementation Requirements
 Provide deterministic edits and execution steps.
@@ -82,32 +87,52 @@ Provide deterministic edits and execution steps.
   - `10-templates/repo-starters/role-repo-template/scripts/build-agent-job-description.py`
 - Ensure generated `AGENTS.md` can be assembled without manual edits.
 
-### 4) Wire workstation runtime for role
-- Add role profile env:
-  - `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
-- Add role service/profile entries in:
-  - `.devcontainer-workstation/docker-compose.yml`
-  - `.devcontainer-workstation/docker-compose.ghcr.yml`
+### 4) Add role profile env
+- File: `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
+- Set role profile defaults needed by the workstation runtime.
 
-### 5) Update workstation launcher touchpoints
-- Update role selection/mapping in `.devcontainer-workstation/scripts/start-role-workstation.sh`.
-- Update launcher guidance in `.devcontainer-workstation/README.md` if role-specific examples or role lists are included.
+### 5) Register role in canonical role registry
+- File: `00-os/role-registry.yml`
+- Add a new role entry with required fields:
+  - `slug`, `display_name`, `shorthand`
+  - `repo_name`
+  - `github_app.app_id_secret`, `github_app.private_key_secret`, `github_app.env_prefix`
+  - `github_app.app_id_value`, `github_app.installation_id_value` (if known)
+  - `compose.service_name`, `compose.profile`, `compose.image_suffix`, `compose.volume_prefix`
+  - `menu_order`, `menu_label`
 
-### 6) Add role to sync/publish workflow matrices
-- Update role matrix entries in:
-  - `.github/workflows/sync-role-repos.yml`
-  - `.github/workflows/publish-role-workstation-images.yml`
-- Ensure role repo naming is consistent (`context-engineering-role-<role-slug>`).
-
-### 7) Run role onboarding preflight validator
+### 6) Regenerate role wiring (do not hand-edit generated sections)
 Run:
 ```bash
+python3 00-os/scripts/generate-role-wiring.py
+```
+This updates generated markers in:
+- `.devcontainer-workstation/docker-compose.yml`
+- `.devcontainer-workstation/docker-compose.ghcr.yml`
+- `.devcontainer-workstation/scripts/start-role-workstation.sh`
+- `.github/workflows/sync-role-repos.yml`
+- `.github/workflows/publish-role-workstation-images.yml`
+
+### 7) Validate generated wiring and onboarding touchpoints
+Run:
+```bash
+python3 00-os/scripts/generate-role-wiring.py --check
+
 10-templates/repo-starters/role-repo-template/scripts/validate-role-onboarding.sh \
   --role-slug <role-slug>
 ```
-Address any missing touchpoints before continuing.
+Address any validation failures before continuing.
 
-### 8) Create public role repo and initial scaffold
+### 8) Validate GitHub App bootstrap conventions
+Run:
+```bash
+00-os/scripts/validate-github-app-setup.sh \
+  --role-slug <role-slug> \
+  --org <github-owner>
+```
+Fix missing org secrets/app installation warnings before publish validation.
+
+### 9) Create public role repo and initial scaffold
 Run:
 ```bash
 10-templates/repo-starters/role-repo-template/scripts/create-public-role-repo.sh \
@@ -115,7 +140,7 @@ Run:
   --owner <github-owner>
 ```
 
-### 9) Verify sync automation and role-repo PR
+### 10) Verify sync automation and role-repo PR
 Run sync workflow (manual or push-triggered) and verify:
 - Role sync job succeeds
 - Sync PR exists in role repo from `sync/role-repo/<role-slug>` to `main`
@@ -125,16 +150,17 @@ Run sync workflow (manual or push-triggered) and verify:
   - `.vscode/settings.json`
   - `README.md`
 
-### 10) Verify image publish and container usability
+### 11) Verify image publish and container usability
 Run publish workflow and verify role job succeeds.
 Validate published image pull/run for the new role profile and confirm instruction files resolve in runtime.
 
-### 11) Capture evidence in PR
+### 12) Capture evidence in PR
 Include run URLs and verification notes for:
 - Role repo creation
 - Sync workflow
 - Publish workflow
 - Container smoke check
+- Role wiring validation runs
 
 ## Acceptance Criteria
 Use checkboxes. Keep these binary.
@@ -143,12 +169,14 @@ Use checkboxes. Keep these binary.
 - [ ] Role instruction source exists at `10-templates/agent-instructions/roles/<role-slug>.md`
 - [ ] Role job spec exists at `10-templates/job-description-spec/roles/<role-slug>.json`
 - [ ] Role profile env exists at `.devcontainer-workstation/codex/role-profiles/<role-slug>.env`
-- [ ] Role is wired in both compose files
-- [ ] Launcher touchpoints updated in `.devcontainer-workstation/scripts/start-role-workstation.sh` and `.devcontainer-workstation/README.md`
-- [ ] Role is wired in sync and publish workflow matrices
+- [ ] Role registry entry exists in `00-os/role-registry.yml`
+- [ ] Role wiring was generated via `00-os/scripts/generate-role-wiring.py`
+- [ ] `python3 00-os/scripts/generate-role-wiring.py --check` passes
+- [ ] Role onboarding validator passes for `<role-slug>`
 - [ ] Public role repo exists at `<github-owner>/context-engineering-role-<role-slug>`
 - [ ] Sync workflow role job succeeded and produced/updated role-repo PR
 - [ ] Publish workflow role job succeeded for the new role
+- [ ] No manual edits were made inside generated marker blocks
 - [ ] Only files listed in Scope were modified
 - [ ] No secrets, tokens, internal hostnames, IPs, or personal data introduced
 


### PR DESCRIPTION
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Provided

Closes #140

## Summary
This PR aligns role-onboarding governance artifacts with the current registry-first workflow and removes hardcoded role slug handling from GitHub App bootstrap validation.

## Changes
- Updated role creation work-order template to require:
  - `00-os/role-registry.yml` as canonical role wiring input
  - `python3 00-os/scripts/generate-role-wiring.py` generation flow
  - generator `--check` and onboarding validator execution
- Updated role creation issue template with the same registry/generator-first requirements
- Refactored `00-os/scripts/validate-github-app-setup.sh` to derive secret names from role slug naming convention:
  - `<ROLE_SLUG_UPPER_SNAKE>_APP_ID`
  - `<ROLE_SLUG_UPPER_SNAKE>_APP_PRIVATE_KEY`
- Updated GitHub App bootstrap runbook to match validator behavior and naming conventions

## Validation
- `bash -n 00-os/scripts/validate-github-app-setup.sh`
- `python3 00-os/scripts/generate-role-wiring.py --check` (with `pyyaml` available)
- `00-os/scripts/validate-github-app-setup.sh --role-slug hr-and-ai-agent`
  - confirms convention-based derivation and expected missing-secret failure mode for an unconfigured new role

## Scope Check
Only these files were modified:
- `.github/ISSUE_TEMPLATE/role-creation-request.md`
- `10-templates/agent-work-orders/role-creation-work-order.md`
- `00-os/scripts/validate-github-app-setup.sh`
- `00-os/runbooks/github-app-bootstrap-validation.md`
