### PR TITLE
Implementation Specialist: Harden role auth self-heal contract for AGENTS generation

### DIFF
--- a/.devcontainer-workstation/README.md
+++ b/.devcontainer-workstation/README.md
@@ -160,6 +160,8 @@ gh auth status --hostname github.com
 gh api graphql -f query='{viewer{login}}' --jq '.data.viewer.login'
 ```
 
+Note: `gh api /user` is not a valid role-identity check for GitHub App auth and can return `403 Resource not accessible by integration`.
+
 If App auth variables are missing, startup logs a warning and continues without App auth.
 
 When `gh` starts failing later with `401 Bad credentials` (expired installation token), run the deterministic re-mint helper before issue/branch/PR flows:

--- a/10-templates/agent-instructions/base.md
+++ b/10-templates/agent-instructions/base.md
@@ -42,7 +42,7 @@ If you are running inside a role workstation container:
 Verification commands:
 
 - `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --hostname github.com`
-- `env -u GH_TOKEN -u GITHUB_TOKEN gh api /user --jq '.login'`
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh api graphql -f query='query { viewer { login } }' --jq '.data.viewer.login'`
 
 Only escalate after re-mint fails. Include:
 

--- a/10-templates/github-app-auth-self-heal-protocol.md
+++ b/10-templates/github-app-auth-self-heal-protocol.md
@@ -1,0 +1,31 @@
+# GitHub App Auth Self-Heal Protocol (Role Workstations)
+
+Apply this protocol when running inside role-scoped workstation containers.
+
+## Mode and authority
+
+- Treat role app auth as authoritative when `ROLE_GITHUB_AUTH_MODE=app`.
+- Do not run `gh auth login` in app mode.
+- Run `gh` with `GH_TOKEN` and `GITHUB_TOKEN` unset so persisted role-app auth is used.
+
+## Deterministic self-heal sequence
+
+1. Prefer wrapper usage for normal GitHub CLI operations:
+   - `gh-role <gh-args>`
+2. If auth is stale or commands fail:
+   - `env -u GH_TOKEN -u GITHUB_TOKEN /usr/local/bin/remint-role-github-app-auth.sh`
+3. Retry the original command via `gh-role`.
+
+## Verification commands
+
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --hostname github.com`
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh api graphql -f query='query { viewer { login } }' --jq '.data.viewer.login'`
+
+## Escalation package (only after re-mint fails)
+
+Include command output for:
+
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --hostname github.com`
+- `ls -l /run/secrets/role_github_app_private_key`
+- `cat /workspace/instructions/role-github-app-auth.env`
+- `env -u GH_TOKEN -u GITHUB_TOKEN /usr/local/bin/remint-role-github-app-auth.sh`

--- a/10-templates/job-description-spec/README.md
+++ b/10-templates/job-description-spec/README.md
@@ -12,6 +12,7 @@ Structured source inputs for deterministic assembly of role-repo `AGENTS.md` fil
 
 - `global.json`
   - Global requirements applied to every role (workflow, authority boundaries, escalation, prohibited actions, quality standards)
+  - May also include `required_protocol_includes` for protocol content that must appear in all generated role contracts
 - `roles/<role-slug>.json`
   - Role-specific requirements and protocol includes
 
@@ -48,6 +49,10 @@ All keys must be JSON arrays of strings.
 2. `roles/<role-slug>.json`
 
 and renders a contract-shaped markdown job description with required sections.
+
+Current global protocol include:
+
+- `10-templates/github-app-auth-self-heal-protocol.md`
 
 ## Notes
 

--- a/10-templates/job-description-spec/global.json
+++ b/10-templates/job-description-spec/global.json
@@ -25,5 +25,8 @@
     "Outputs must be deterministic, auditable, and tied to explicit requirements.",
     "Changes must be review-ready with clear rationale and minimal drift.",
     "Use canonical role terminology consistently across artifacts."
+  ],
+  "required_protocol_includes": [
+    "10-templates/github-app-auth-self-heal-protocol.md"
   ]
 }


### PR DESCRIPTION
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required

Closes #149

## Summary
Hardened role-workstation GitHub App auth self-heal guidance so generated role `AGENTS.md` contracts include deterministic re-mint protocol content, and aligned base instructions/docs with App-auth-safe verification.

## Changes
- Added canonical protocol include source:
  - `10-templates/github-app-auth-self-heal-protocol.md`
- Wired protocol into all generated role contracts:
  - `10-templates/job-description-spec/global.json` (`required_protocol_includes`)
- Updated base instruction verification for App auth:
  - `10-templates/agent-instructions/base.md`
  - replaced `/user` identity check with GraphQL `viewer.login`
- Updated spec/docs alignment:
  - `10-templates/job-description-spec/README.md`
  - `.devcontainer-workstation/README.md`

## Affected Roles
Global contract include now applies to generated `AGENTS.md` for:
- implementation-specialist
- compliance-officer
- systems-architect
- hr-ai-agent-specialist

## Validation Evidence
- JSON/schema sanity:
  - `python3 -m json.tool 10-templates/job-description-spec/global.json`
- Rendered role templates confirm protocol include is embedded:
  - `render-role-repo-template.sh --role-slug implementation-specialist ...`
  - `render-role-repo-template.sh --role-slug hr-ai-agent-specialist ...`
- Verified rendered `AGENTS.md` contains:
  - `## Required Protocol Includes`
  - `# GitHub App Auth Self-Heal Protocol (Role Workstations)`
  - GraphQL viewer verification command

## Notes
This change intentionally keeps runtime auth boundaries intact:
- No autonomous privilege escalation added
- No user-mode `gh auth login` guidance in app mode
- Self-heal remains deterministic via in-container re-mint helper and role-safe `gh-role` wrapper
